### PR TITLE
Add isOptional() to ParamConverter configuration

### DIFF
--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -59,6 +59,16 @@ class ParamConverter implements ConfigurationInterface
         $this->options = $options;
     }
 
+    public function isOptional()
+    {
+        return $this->optional;
+    }
+
+    public function setOptional($optional)
+    {
+        $this->optional = $optional;
+    }
+
     public function getAliasName()
     {
         return 'converters';

--- a/Controller/ParamConverterListener.php
+++ b/Controller/ParamConverterListener.php
@@ -58,6 +58,7 @@ class ParamConverterListener
                 $configuration = new ParamConverter();
                 $configuration->setName($param->getName());
                 $configuration->setClass($param->getClass()->getName());
+                $configuration->setOptional($param->isOptional());
 
                 $this->manager->apply($request, $configuration);
             }


### PR DESCRIPTION
This allows you to set the param to null if it is not given or not found.
