### PR TITLE
[Resources] fixed routing parameters that used the old syntax (:var inste

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -11,7 +11,7 @@ they can be injected as controller method arguments::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 
     /**
-     * @Route("/blog/:id")
+     * @Route("/blog/{id}")
      * @ParamConverter("post", class="SensioBlogBundle:Post")
      */
     public function showAction(Post $post)

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -136,7 +136,7 @@ This example shows all the available annotations in action::
         }
 
         /**
-         * @Route("/:id")
+         * @Route("/{id}")
          * @ParamConverter("post", class="SensioBlogBundle:Post")
          * @Template("SensioBlogBundle:Annot:post", vars={"post"})
          * @Cache(smaxage="15")
@@ -150,7 +150,7 @@ As the ``showAction`` method follows some conventions, you can omit some
 annotations::
 
     /**
-     * @Route("/:id")
+     * @Route("/{id}")
      * @Cache(smaxage="15")
      */
     public function showAction(Post $post)


### PR DESCRIPTION
[Resources] fixed routing parameters that used the old syntax (:var instead of {var}).
