### PR TITLE
Better default route name formatter to follow conventions.

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -63,16 +63,14 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
     {
         $routeName = parent::getDefaultRouteName($class, $method);
 
-        return str_replace(array(
-            'bundle',
-            'controller',
-            'action',
-            '__',
+        return preg_replace(array(
+            '/(bundle|controller)_/',
+            '/action$/',
+            '/__/'
         ), array(
-            null,
-            null,
-            null,
             '_',
+            null,
+            '_'
         ), $routeName);
     }
 }


### PR DESCRIPTION
Better default route name formatter to follow conventions. The words "action", "bundle", "controller" can be part of the name and should not be always removed.

```
acme_bundlerbundle_transactioncontroller_index
```

must become

```
acme_bundler_transaction_index
```

before this fix, it is

```
acme_r_trans_index
```
