### PR TITLE
[Routing] Removes the action keyword from the default route names

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -73,4 +73,15 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
             '_'
         ), $routeName);
     }
+
+    /**
+     * Removes the action keyword from the route name
+     *
+     * @param  string $prefix
+     * @param  ReflectionMethod $method A ReflectionMethod instance
+     * @return string
+     */    
+    protected function getDefaultMethodRouteName($prefix, \ReflectionMethod $method) {
+        return str_replace('action', '', parent::getDefaultMethodRouteName($prefix, $method));
+    }
 }


### PR DESCRIPTION
For example:

```
/**
 * Users controller.
 *
 * @Route("/site/users", name="users")
 */
class UsersController extends Controller {

    /**
     * @Route("/list")
     */
    public function listAction() {

    }

    /**
     * @Route("/search")
     */
    public function searchAction() {

    }    
    /**
     * @Route("/custom", name="custom_route_name")
     */
    public function customAction() {

    }
}
```

will generate the routes:

```
users_list                         ANY /site/users/list
users_search                    ANY /site/users/search
custom_route_name          ANY /site/users/search
```

See  #PR1866  https://github.com/symfony/symfony/pull/1866 for more details
