### PR TITLE
[doc] Add missing Method annotation import

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -99,6 +99,7 @@ This example shows all the available annotations in action::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 
     /**
      * @Route("/blog")


### PR DESCRIPTION
Example can't work without importing the Method annotation.
