### PR TITLE
Add template name guesser service

### DIFF
--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -35,6 +35,8 @@ class SensioFrameworkExtraExtension extends Extension
         $configuration = new Configuration();
 
         $config = $processor->process($configuration->getConfigTree(), $configs);
+        
+        $loader->load('services.xml');
 
         $annotationsToLoad = array();
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sensio_framework_extra.view.guesser.class">Sensio\Bundle\FrameworkExtraBundle\Templating\TemplateGuesser</parameter>
+    </parameters>
+
+    <services>
+        <service id="sensio_framework_extra.view.guesser" class="%sensio_framework_extra.view.guesser.class%">
+            <argument type="service" id="kernel" />
+        </service>
+    </services>
+
+</container>

--- a/Templating/TemplateGuesser.php
+++ b/Templating/TemplateGuesser.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Templating;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * The TemplateGuesser class handles the guessing of template name based on controller
+ *
+ * @author     Fabien Potencier <fabien@symfony.com>
+ */
+class TemplateGuesser
+{
+    /**
+     * @var Symfony\Component\HttpKernel\KernelInterface
+     */
+    protected $kernel;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container The service container instance
+     */
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+    
+    /**
+     * Guesses and returns the template name to render based on the controller
+     * and action names.
+     *
+     * @param array $controller An array storing the controller object and action method
+     * @param Request $request A Request instance
+     * @param string $engine
+     * @return TemplateReference template reference
+     * @throws \InvalidArgumentException
+     */
+    public function guessTemplateName($controller, Request $request, $engine = 'twig')
+    {
+        if (!preg_match('/Controller\\\(.+)Controller$/', get_class($controller[0]), $matchController)) {
+            throw new \InvalidArgumentException(sprintf('The "%s" class does not look like a controller class (it must be in a "Controller" sub-namespace and the class name must end with "Controller")', get_class($controller[0])));
+
+        }
+        if (!preg_match('/^(.+)Action$/', $controller[1], $matchAction)) {
+            throw new \InvalidArgumentException(sprintf('The "%s" method does not look like an action method (it does not end with Action)', $controller[1]));
+        }
+
+        $bundle = $this->getBundleForClass(get_class($controller[0]));
+
+        return new TemplateReference($bundle->getName(), $matchController[1], $matchAction[1], $request->getRequestFormat(), $engine);
+    }
+
+    /**
+     * Returns the Bundle instance in which the given class name is located.
+     *
+     * @param string $class A fully qualified controller class name
+     * @param Bundle $bundle A Bundle instance
+     * @throws \InvalidArgumentException
+     */
+    protected function getBundleForClass($class)
+    {
+        $namespace = strtr(dirname(strtr($class, '\\', '/')), '/', '\\');
+        foreach ($this->kernel->getBundles() as $bundle) {
+            if (0 === strpos($namespace, $bundle->getNamespace())) {
+                return $bundle;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('The "%s" class does not belong to a registered bundle.', $class));
+    }
+}


### PR DESCRIPTION
This change would help @schmittjoh's override of template name guessing in [JMSDiExtraBundle](/schmittjoh/JMSDiExtraBundle)  to be implemented in a way that does not disrupt [FOSRestBundle](/FriendsOfSymfony/FOSRestBundle) as described in schmittjoh/JMSDiExtraBundle#14.
