### PR TITLE
Make DoctrineParamConverter smarter in how it handles request attributes.

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -18,6 +18,14 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * DoctrineConverter.
+ * 
+ * The DoctrineConverter can recieve three options in the options array:
+ *   entity_manager - the entity manager to user for fetching the object
+ * 2. request_atttribute - the name of the attribute you should use to fetch the item (Defaults to 'id').
+ * 3. object_attribute - the name of the object attribute used for fetching the object (Defaults to false - i.e. use the objects natural ID.).
+ * 
+ * 
+ * 
  *
  * @author     Fabien Potencier <fabien@symfony.com>
  */
@@ -37,31 +45,38 @@ class DoctrineParamConverter implements ParamConverterInterface
     {
         $class = $configuration->getClass();
         $options = $this->getOptions($configuration);
-
-        // find by identifier?
-        if (false === $object = $this->find($class, $request, $options)) {
-            // find by criteria
-            if (false === $object = $this->findOneBy($class, $request, $options)) {
-                throw new \LogicException('Unable to guess how to get a Doctrine instance from the request information.');
+        
+        $attribute = (isset($options['request_attribute']) ? $options['request_attribute'] : 'id' );
+        $queryAttribute = (isset($options['object_attribute']) ? $options['object_attribute'] : false );
+        
+        if (false === $queryAttribute) {
+            // find by identifier?
+            $object = $this->find($class, $request, $options, $attribute);
+            if (false === $object ) {
+                // find by criteria
+                if (false === $object = $this->findOneBy($class, $request, $options)) {
+                    throw new \LogicException('Unable to guess how to get a Doctrine instance from the request information.');
+                }
             }
+        } else {
+            $criteria = array($queryAttribute => $request->attributes->get($attribute));
+            $object = $this->registry->getRepository($class, $options['entity_manager'])->findOneBy($criteria);
         }
 
         if (null === $object && false === $configuration->isOptional()) {
             throw new NotFoundHttpException(sprintf('%s object not found.', $class));
         }
-
         $request->attributes->set($configuration->getName(), $object);
 
         return true;
     }
 
-    protected function find($class, Request $request, $options)
+    protected function find($class, Request $request, $options, $attribute)
     {
-        if (!$request->attributes->has('id')) {
+        if (!$request->attributes->has($attribute)) {
             return false;
         }
-
-        return $this->registry->getRepository($class, $options['entity_manager'])->find($request->attributes->get('id'));
+        return $this->registry->getRepository($class, $options['entity_manager'])->find($request->attributes->get($attribute));
     }
 
     protected function findOneBy($class, Request $request, $options)
@@ -103,6 +118,8 @@ class DoctrineParamConverter implements ParamConverterInterface
     {
         return array_replace(array(
             'entity_manager' => 'default',
+            'request_atttribute' => 'id',
+            'object_attribute' => false
         ), $configuration->getOptions());
     }
 }

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -19,19 +19,39 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
     
     public function setUp()
     {
+<<<<<<< HEAD
         if (!interface_exists('Doctrine\Common\Persistence\ManagerRegistry')) {
             $this->markTestSkipped();
+=======
+            if (!interface_exists('Doctrine\Common\Persistence\ManagerRegistry')) {
+            $this->markTestSkipped('Missing Doctrine\Common\Persistence\ManagerRegistry');
+>>>>>>> 62cf316... This commit changes the DoctrineParamConverter to handle paths like:
         }
 
         $this->manager = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
         $this->converter = new DoctrineParamConverter($this->manager);
+<<<<<<< HEAD
+=======
+        
+        $this->objectRepository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $this->objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->manager->expects($this->any())->method('getRepository')
+                      ->will($this->returnValue($this->objectRepository));
+        $this->manager->expects($this->any())->method('getManager')
+                      ->will($this->returnValue($this->objectManager));
+        
+>>>>>>> 62cf316... This commit changes the DoctrineParamConverter to handle paths like:
     }
     
     public function createConfiguration($class = null, array $options = null)
     {
         $config = $this->getMock(
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface', array(
+<<<<<<< HEAD
             'getClass', 'getAliasName', 'getOptions'
+=======
+            'getClass', 'getAliasName', 'getOptions', 'isOptional', 'getName', 
+>>>>>>> 62cf316... This commit changes the DoctrineParamConverter to handle paths like:
         ));
         if ($options !== null) {
             $config->expects($this->once())
@@ -50,6 +70,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
         $config = $this->createConfiguration(null, array());
+<<<<<<< HEAD
         $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
         
         $this->manager->expects($this->never())->method('find');
@@ -61,6 +82,82 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->converter->apply($request, $config);
     }
     
+=======
+        $this->setExpectedException('LogicException');
+        $this->converter->apply($request, $config);
+    }
+
+    public function testNonOptionalNotFound()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration(null, array());
+        $config->expects($this->once())
+               ->method("isOptional")
+               ->will($this->returnValue(false));
+                
+        $request->attributes->set("id", "34");
+        
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->converter->apply($request, $config);
+    }
+    /**
+     * Old behaviour, we use the id attribute to query for the user by id
+     */
+    public function testApplyDefault()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration("User", array());
+        
+        $request->attributes->set("id", "testName");
+        
+        $this->objectRepository->expects($this->once())->method('find')
+                ->with($this->equalTo("testName"))->will($this->returnValue("object"))
+                ;
+        $this->objectRepository->expects($this->never())->method('findBy');
+        
+        $ret = $this->converter->apply($request, $config);
+        
+        $this->assertTrue($ret, "We should have found an object");
+        $this->assertEquals("object", $request->attributes->get($config->getName()));
+    }
+
+    public function testApplyWithRequestAttribute()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration("User", array('request_attribute' => 'name'));
+        
+        $request->attributes->set("name", "testName");
+        
+        $this->objectRepository->expects($this->once())->method('find')
+                ->with($this->equalTo("testName"))->will($this->returnValue("object"))
+                ;
+        $this->objectRepository->expects($this->never())->method('findBy');
+        
+        $ret = $this->converter->apply($request, $config);
+        
+        $this->assertTrue($ret, "We should have found an object");
+        $this->assertEquals("object", $request->attributes->get($config->getName()));
+    }
+
+        public function testApplyWithRequestAttributeAndQueryAttribute()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration("User", array('request_attribute' => 'name'));
+        
+        $request->attributes->set("name", "testName");
+        
+        $this->objectRepository->expects($this->once())->method('find')
+                ->with($this->equalTo("testName"))->will($this->returnValue("object"))
+                ;
+        $this->objectRepository->expects($this->never())->method('findBy');
+        
+        $ret = $this->converter->apply($request, $config);
+        
+        $this->assertTrue($ret, "We should have found an object");
+        $this->assertEquals("object", $request->attributes->get($config->getName()));
+    }
+
+>>>>>>> 62cf316... This commit changes the DoctrineParamConverter to handle paths like:
     public function testSupports()
     {
         $config = $this->createConfiguration('stdClass', array());
@@ -70,18 +167,33 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
                         ->with($this->equalTo('stdClass'))
                         ->will($this->returnValue( false ));
         
+<<<<<<< HEAD
         $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
         $objectManager->expects($this->once())
+=======
+        $this->objectManager->expects($this->once())
+>>>>>>> 62cf316... This commit changes the DoctrineParamConverter to handle paths like:
                       ->method('getMetadataFactory')
                       ->will($this->returnValue($metadataFactory));
         
         $this->manager->expects($this->once())
                       ->method('getManager')
                       ->with($this->equalTo('default'))
+<<<<<<< HEAD
                       ->will($this->returnValue($objectManager));
         
         $ret = $this->converter->supports($config);
         
         $this->assertTrue($ret, "Should be supported");
+=======
+                      ->will($this->returnValue($this->objectManager));
+        
+        $ret = $this->converter->supports($config);
+        
+        
+        
+        $this->assertTrue($ret, "Should be supported");
+        
+>>>>>>> 62cf316... This commit changes the DoctrineParamConverter to handle paths like:
     }
 }


### PR DESCRIPTION
As the DoctrineParamConverter stands, it is hard to propperly controll which request attribute will be used for fetching the object - and also to be sure you know how the query will be done. This PR will add some flexibility to how this is done by adding two extra options to the ParamConverter::

```
 'request_atttribute' => 'id',
 'object_attribute' => false
```

request_attribute defines which attribute in the route should be used, so if you got a route like::
   /{user}/{group}

Then ::

   @ParamConverter("user", class="CommonBundle:User", options={'request_atttribute' => "user})

Will find the correct value to use.

by beeing able to assign which request variable should be used for a
given provider.

It also adds support for defining how the object should be queried.
