### PR TITLE
Changed the default value for the entity manager name

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -104,7 +104,7 @@ class DoctrineParamConverter implements ParamConverterInterface
     protected function getOptions(ConfigurationInterface $configuration)
     {
         return array_replace(array(
-            'entity_manager' => 'default',
+            'entity_manager' => null,
         ), $configuration->getOptions());
     }
 }


### PR DESCRIPTION
Using null fetches the default entity manager from the registry (which always
exists when the ORM is configured) whereas using 'default' fetches the entity
manager named 'default' (which exists when using the short notation because
it is the name used in this case but is not enforced)
