### PR TITLE
Fix Cache annotation when set at Class level fixes #66

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -55,7 +55,7 @@ class ControllerListener
         $method = $object->getMethod($controller[1]);
 
         $request = $event->getRequest();
-        foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
+        foreach (array_merge($this->reader->getClassAnnotations($object), $this->reader->getMethodAnnotations($method)) as $configuration) {
             if ($configuration instanceof ConfigurationInterface) {
                 $request->attributes->set('_'.$configuration->getAliasName(), $configuration);
             }

--- a/Tests/EventListener/ControllerListenerTest.php
+++ b/Tests/EventListener/ControllerListenerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClassAndMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtMethod;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ControllerListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->listener = new ControllerListener(new AnnotationReader());
+        $this->request = $this->createRequest();
+    }
+
+    public function tearDown()
+    {
+        $this->listener = null;
+        $this->request = null;
+    }
+
+    public function testCacheAnnotationAtMethod()
+    {
+        $controller = new FooControllerCacheAtMethod();
+
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAtMethod::METHOD_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
+    public function testCacheAnnotationAtClass()
+    {
+        $controller = new FooControllerCacheAtClass();
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAtClass::CLASS_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
+    public function testCacheAnnotationAtClassAndMethod()
+    {
+        $controller = new FooControllerCacheAtClassAndMethod();
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAtClassAndMethod::METHOD_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+
+        $this->event = $this->getFilterControllerEvent(array($controller, 'bar2Action'), $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAtClassAndMethod::CLASS_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
+    protected function createRequest(Cache $cache = null)
+    {
+        return new Request(array(), array(), array(
+            '_cache' => $cache,
+        ));
+    }
+
+    protected function getFilterControllerEvent($controller, Request $request)
+    {
+        $mockKernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', array('', ''));
+        return new FilterControllerEvent($mockKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
+    }
+
+    protected function getReadedCache()
+    {
+        return $this->request->attributes->get('_cache');
+    }
+}

--- a/Tests/EventListener/Fixture/FooControllerCacheAtClass.php
+++ b/Tests/EventListener/Fixture/FooControllerCacheAtClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+/**
+ * @Cache(smaxage="20")
+ */
+class FooControllerCacheAtClass
+{
+    const CLASS_SMAXAGE = 20;
+
+    public function barAction()
+    {
+    }
+}

--- a/Tests/EventListener/Fixture/FooControllerCacheAtClassAndMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerCacheAtClassAndMethod.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+/**
+ * @Cache(smaxage="20")
+ */
+class FooControllerCacheAtClassAndMethod
+{
+    const CLASS_SMAXAGE = 20;
+    const METHOD_SMAXAGE = 15;
+
+    /**
+     * @Cache(smaxage="15")
+     */
+    public function barAction()
+    {
+    }
+
+    public function bar2Action()
+    {
+    }
+}

--- a/Tests/EventListener/Fixture/FooControllerCacheAtMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerCacheAtMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+class FooControllerCacheAtMethod
+{
+    const METHOD_SMAXAGE = 15;
+
+    /**
+     * @Cache(smaxage="15")
+     */
+    public function barAction()
+    {
+    }
+}


### PR DESCRIPTION
Cache annotation is ignored when it is set at class level, this patch makes Cache annotations work at class level and if there is a Cache annotation at method level, it overrides class configuration.

Also, 2 small PHPDoc fixes namespacing variables
