### PR TITLE
Invalid property isStreamable in Template class

### DIFF
--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -47,7 +47,7 @@ class Template extends ConfigurationAnnotation
      *
      * @var Boolean
      */
-    protected $isStreamable = false;
+    protected $streamable = false;
 
     /**
      * Returns the array of templates variables.


### PR DESCRIPTION
The property streamable on line 67 does not exist, resulting in an error when calling the function. The property isStreamable is renamed to streamable in order to solve this problem.
