### PR TITLE
Make Template guesser look at parent classes for bundle (The better way)

### DIFF
--- a/Templating/TemplateGuesser.php
+++ b/Templating/TemplateGuesser.php
@@ -74,16 +74,15 @@ class TemplateGuesser
         $reflectionClass = new \ReflectionClass($class);
         $bundles = $this->kernel->getBundles();
 
-        $currentClass = $reflectionClass;
         do {
-            $namespace = $currentClass->getNamespaceName();
+            $namespace = $reflectionClass->getNamespaceName();
             foreach ($bundles as $bundle) {
                 if (0 === strpos($namespace, $bundle->getNamespace())) {
                     return $bundle;
                 }
             }
-            $currentClass = $currentClass->getParentClass();
-        } while ($currentClass);
+            $reflectionClass = $reflectionClass->getParentClass();
+        } while ($reflectionClass);
 
         throw new \InvalidArgumentException(sprintf('The "%s" class does not belong to a registered bundle.', $class));
     }


### PR DESCRIPTION
Solves the same issue as this pull request: #98

but is a better way to do that - inside getBundleForClass() method and without catching exceptions (which must be slower and would be the default behavior for all secured via annotations controllers with the latest JMSSecurityExtraBundle)
