### PR TITLE
Support for "Vary"-headers in "Cache" annotation

### DIFF
--- a/Configuration/Cache.php
+++ b/Configuration/Cache.php
@@ -50,6 +50,13 @@ class Cache extends ConfigurationAnnotation
     protected $public;
 
     /**
+     * Additional "Vary:"-headers
+     *
+     * @var array
+     */
+    protected $vary = array();
+
+    /**
      * Returns the expiration date for the Expires header field.
      *
      * @return string
@@ -129,6 +136,26 @@ class Cache extends ConfigurationAnnotation
     public function setPublic($public)
     {
         $this->public = (Boolean) $public;
+    }
+
+    /**
+     * Returns the custom "Vary"-headers
+     *
+     * @return array
+     */
+    public function getVary()
+    {
+        return $this->vary;
+    }
+
+    /**
+     * Add additional "Vary:"-headers
+     *
+     * @param array $vary
+     */
+    public function setVary($vary)
+    {
+        $this->vary = $vary;
     }
 
     /**

--- a/EventListener/CacheListener.php
+++ b/EventListener/CacheListener.php
@@ -52,6 +52,10 @@ class CacheListener
             $response->setExpires($date);
         }
 
+        if (null !== $configuration->getVary()) {
+            $response->setVary($configuration->getVary());
+        }
+
         if ($configuration->isPublic()) {
             $response->setPublic();
         }

--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -51,6 +51,7 @@ Annotation                     Response Method
 ``@Cache(expires="tomorrow")`` ``$response->setExpires()``
 ``@Cache(smaxage="15")``       ``$response->setSharedMaxAge()``
 ``@Cache(maxage="15")``        ``$response->setMaxAge()``
+``@Cache(vary=["Cookie"])``    ``$response->setVary()``
 ============================== ===============
 
 .. note::


### PR DESCRIPTION
Just allows to use `vary` in the Cache annotation

```
 * @Cache(maxage="86400",smaxage="21600",vary={"Cookie"})
```
