### PR TITLE
ManagerRegistry returns the default Manager when the name is null

### DIFF
--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -77,7 +77,6 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         
         $this->manager->expects($this->once())
                       ->method('getManager')
-                      ->with($this->equalTo('default'))
                       ->will($this->returnValue($objectManager));
         
         $ret = $this->converter->supports($config);


### PR DESCRIPTION
Fixes the failing tests caused by the changed way of getting the default Manager.
