### PR TITLE
[ParamConverter] "entity_manager" is not required for every configuration

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -91,6 +91,10 @@ class DoctrineParamConverter implements ParamConverterInterface
 
         $options = $this->getOptions($configuration);
 
+        if (false === isset($options['entity_manager'])) { 
+            return false; 
+        }
+
         // Doctrine Entity?
         try {
             $this->registry->getEntityManager($options['entity_manager'])->getClassMetadata($configuration->getClass());


### PR DESCRIPTION
Fixes the issue with converters that don't require the "entity_manager" option.
