### PR TITLE
this add class for ParamConverter without class

### DIFF
--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -75,6 +75,8 @@ class ParamConverterListener
                 $configuration->setClass($param->getClass()->getName());
 
                 $configurations[$name] = $configuration;
+            } elseif (null === $configurations[$name]->getClass()) {
+                $configurations[$name]->setClass($param->getClass()->getName());
             }
 
             $configurations[$name]->setIsOptional($param->isOptional());


### PR DESCRIPTION
Hi,

This add the possibility to configure the paramConverter without class param, when the parameter has a typehint:

``` php
<?php
use Acme\BookBundle\Model\Book;
    /**
     *  @Route("/edit-book/{id}", name="edit_book")
     *  @ParamConverter("book", options={"option1"="foo"})
     *  @Template()
     */
    public function editBookAction(Book $book)
    {
    }
```
