### PR TITLE
Do not covert if annotation was not imported on controller.

### DIFF
--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -49,10 +49,14 @@ class ParamConverterListener
         $request = $event->getRequest();
         $configurations = array();
 
-        if ($configuration = $request->attributes->get('_converters')) {
-            foreach (is_array($configuration) ? $configuration : array($configuration) as $configuration) {
-                $configurations[$configuration->getName()] = $configuration;
-            }
+        // there is no work for us if paramConverter annotation was not imported.
+        if (!$request->attributes->has('_converters')) {
+            return;
+        }
+        
+        $configuration = $request->attributes->get('_converters');
+        foreach (is_array($configuration) ? $configuration : array($configuration) as $configuration) {
+            $configurations[$configuration->getName()] = $configuration;
         }
 
         if (is_array($controller)) {


### PR DESCRIPTION
I have a controller without `paramConverter` annotation and next situation: I have a parameter which is not present in routing and could be set only for internal calls (e.g. `forward`). It is optional one so no problem if it is not set. And I get an exception with message `Unable to guess how to get a Doctrine instance from the request information.` from `DoctrineParamConverter`. It is quite surprising as I don`t use it.

The other strange thing: nevertheless the parameter is optional I got an exception. 
