### PR TITLE
Fixed the composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.*",
-        "doctrine/common": ">=2.0"
+        "symfony/framework-bundle": "2.0.*",
+        "doctrine/common": ">=2.1,<2.4-dev"
     },
     "autoload": {
         "psr-0": { "Sensio\\Bundle\\FrameworkExtraBundle": "" }


### PR DESCRIPTION
The composer constraints are wrong currently: the unbound constraint on common means that you cannot release without knowing all future releases of Common (as tags cannot be fixed later) and the FrameworkBundle requirement was wrong as the 2.0 branch does not work with 2.1
When merging the 2.0 branch into master, you will of course need to update the constraint to `2.1.*`

Btw, you should probably tag a release of the bundle as the default behavior in composer will change at the end of the month, setting the minimal stability to stable instead of dev (which is the default now to let people do the switch as there was no stability flag until one month ago)
