### PR TITLE
Added a branch alias for the master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     "autoload": {
         "psr-0": { "Sensio\\Bundle\\FrameworkExtraBundle": "" }
     },
-    "target-dir": "Sensio/Bundle/FrameworkExtraBundle"
+    "target-dir": "Sensio/Bundle/FrameworkExtraBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This will allow other bundles depending on it to avoid the unbound constraint.

Note that I haven't fixed the constraint here to avoid conflicts when merging 2.0 into master after #125. Tell me if you prefer having the change in this PR.
