### PR TITLE
fix overzealous convert

### DIFF
--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -69,6 +69,12 @@ class ParamConverterListener
 
             $name = $param->getName();
 
+            if ($request->attributes->has($name)
+                || $param->getClass()->isInstance($request)
+            ) {
+                continue;
+            }
+
             if (!isset($configurations[$name])) {
                 $configuration = new ParamConverter(array());
                 $configuration->setName($name);


### PR DESCRIPTION
do not attempt to convert anything that already has a request attribute set or that is a Request instance
