### PR TITLE
Custom request parameter name in options

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -57,11 +57,12 @@ class DoctrineParamConverter implements ParamConverterInterface
 
     protected function find($class, Request $request, $options)
     {
-        if (!$request->attributes->has('id')) {
+        $key = isset($options['id']) ? $options['id'] : 'id';
+        if (!$request->attributes->has($key)) {
             return false;
         }
 
-        return $this->registry->getRepository($class, $options['entity_manager'])->find($request->attributes->get('id'));
+        return $this->registry->getRepository($class, $options['entity_manager'])->find($request->attributes->get($key));
     }
 
     protected function findOneBy($class, Request $request, $options)


### PR DESCRIPTION
Model id parameter name hardcoded in DoctrineParamConverter::find as id. This fix adds parameter name  mapping.

``` php

     * @Route   ("/{user}/show")
     * @ParamConverter("user", class="MillwrightUserBundle:User", options={"id" = "user"})
     * @Template()
     *
     * @return array
     */
    public function showAction(UserInterface $user)
    {
    }
```
