### PR TITLE
[ParamConverters] Object ParamConverter

### DIFF
--- a/Request/ParamConverter/ObjectParamConverter.php
+++ b/Request/ParamConverter/ObjectParamConverter.php
@@ -22,8 +22,8 @@ use Symfony\Component\HttpFoundation\Request;
  * parameters only, security problems can be avoided and a central
  * location for filtering input data is available.
  *
- * Data is retrieved from query when GET/HEAD request
- * and from "request" if else.
+ * Data is only ever retrieved from the query part of the request,
+ * use the form framework for transorming POST data into objects.
  *
  * Converter can be used to generate criteria/filtering struct objects
  * that are passed to the model layer.
@@ -51,10 +51,8 @@ class ObjectParamConverter implements ParamConverterInterface
         $param  = $configuration->getName();
         $method = $request->getMethod();
 
-        if (in_array($method, array("GET", "HEAD")) && $request->query->has($param)) {
+        if ($request->query->has($param) && !$request->request->has($param)) {
             $data = $request->query->get($param, array());
-        } else if ($request->request->has($param)) {
-            $data = $request->request->get($param, array());
         } else {
             $data = array();
         }

--- a/Request/ParamConverter/ObjectParamConverter.php
+++ b/Request/ParamConverter/ObjectParamConverter.php
@@ -1,12 +1,5 @@
 <?php
 
-namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
-
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpFoundation\Request;
-
 /*
  * This file is part of the Symfony framework.
  *
@@ -15,6 +8,13 @@ use Symfony\Component\HttpFoundation\Request;
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Converts arrays into objects by mapping keys onto
@@ -74,6 +74,8 @@ class ObjectParamConverter implements ParamConverterInterface
         }
 
         $request->attributes->set($param, $object);
+
+        return true;
     }
 
     private function convertClass($class, $data)
@@ -89,7 +91,7 @@ class ObjectParamConverter implements ParamConverterInterface
     {
         $args = array();
 
-        if ( ! $constructor) {
+        if (!$constructor) {
             return array();
         }
 

--- a/Request/ParamConverter/ObjectParamConverter.php
+++ b/Request/ParamConverter/ObjectParamConverter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Request;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Converts arrays into objects by mapping keys onto
+ * constructor arguments. By restricing access to constructor
+ * parameters only, security problems can be avoided and a central
+ * location for filtering input data is available.
+ *
+ * Data is retrieved from query when GET/HEAD request
+ * and from "request" if else.
+ *
+ * Converter can be used to generate criteria/filtering struct objects
+ * that are passed to the model layer.
+ *
+ * Conversion works recursivly and with a special case for DateTime objects.
+ *
+ * Important note: This converter has to run AFTER any persistent object
+ * converter such as the DoctrineParamConverter, so that data from the database
+ * is preferred over user input data. Otherwise attackers could snuck in
+ * objects to operate on. This is why only constructor arguments are mapped.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
+class ObjectParamConverter implements ParamConverterInterface
+{
+    private $validator;
+
+    public function __construct(ValidatorInterface $validator = null)
+    {
+        $this->validator = $validator;
+    }
+
+    public function apply(Request $request, ConfigurationInterface $configuration)
+    {
+        $param  = $configuration->getName();
+        $method = $request->getMethod();
+
+        if (in_array($method, array("GET", "HEAD")) && $request->query->has($param)) {
+            $data = $request->query->get($param, array());
+        } else if ($request->request->has($param)) {
+            $data = $request->request->get($param, array());
+        } else {
+            $data = array();
+        }
+
+        $class  = $configuration->getClass();
+        $object = $this->convertClass($class, $data);
+
+        if ($this->validator) {
+            $options = $configuration->getOptions();
+            $groups  = isset($options['validation_groups'])
+                ? (array)$options['validation_groups']
+                : null;
+
+            $cvl = $this->validator->validate($object, $groups);
+
+            if (count($cvl) > 0) {
+                throw new HttpException(400, (string)$cvl);
+            }
+        }
+
+        $request->attributes->set($param, $object);
+    }
+
+    private function convertClass($class, $data)
+    {
+        $reflClass   = new \ReflectionClass($class);
+        $constructor = $reflClass->getConstructor();
+        $args        = $this->convertClassArguments($constructor, $data);
+
+        return $reflClass->newInstanceArgs($args);
+    }
+
+    private function convertClassArguments($constructor, $data)
+    {
+        $args = array();
+
+        if ( ! $constructor) {
+            return array();
+        }
+
+        if (is_scalar($data)) {
+            return array($data);
+        }
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $argValue      = null;
+            $parameterName = $parameter->getName();
+
+            if (isset($data[$parameterName])) {
+                $argValue = $data[$parameterName];
+
+                if ($parameter->getClass()) {
+                    if ($parameter->getClass()->getName() == "DateTime") {
+                        $argValue = new \DateTime($argValue);
+                    } else if (is_array($argValue)) {
+                        $argValue = $this->convertClass($parameter->getClass()->getName(), $argValue);
+                    }
+                }
+
+            } else if ($parameter->isOptional()) {
+                $argValue = $parameter->getDefaultValue();
+            } else {
+                throw new HttpException(400, "Missing parameter '" . $parameterName . "'");
+            }
+
+            $args[] = $argValue;
+        }
+
+        return $args;
+    }
+
+    public function supports(ConfigurationInterface $configuration)
+    {
+        return $configuration->getClass() !== null;
+    }
+}
+

--- a/Request/ParamConverter/ObjectParamConverter.php
+++ b/Request/ParamConverter/ObjectParamConverter.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  * location for filtering input data is available.
  *
  * Data is only ever retrieved from the query part of the request,
- * use the form framework for transorming POST data into objects.
+ * use the form framework for transforming POST data into objects.
  *
  * Converter can be used to generate criteria/filtering struct objects
  * that are passed to the model layer.
@@ -39,13 +39,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ObjectParamConverter implements ParamConverterInterface
 {
-    private $validator;
-
-    public function __construct(ValidatorInterface $validator = null)
-    {
-        $this->validator = $validator;
-    }
-
     public function apply(Request $request, ConfigurationInterface $configuration)
     {
         $param  = $configuration->getName();
@@ -59,19 +52,6 @@ class ObjectParamConverter implements ParamConverterInterface
 
         $class  = $configuration->getClass();
         $object = $this->convertClass($class, $data);
-
-        if ($this->validator) {
-            $options = $configuration->getOptions();
-            $groups  = isset($options['validation_groups'])
-                ? (array)$options['validation_groups']
-                : null;
-
-            $cvl = $this->validator->validate($object, $groups);
-
-            if (count($cvl) > 0) {
-                throw new HttpException(400, (string)$cvl);
-            }
-        }
 
         $request->attributes->set($param, $object);
 

--- a/Request/ParamConverter/ObjectParamConverter.php
+++ b/Request/ParamConverter/ObjectParamConverter.php
@@ -45,8 +45,8 @@ class ObjectParamConverter implements ParamConverterInterface
         $options = $configuration->getOptions();
         $part    = isset($options['part']) ? $options['part'] : 'query';
 
-        if (!in_array($part, array('attributes', 'query', 'request', 'cookies'))) {
-            throw new \RuntmeException("Invalid part to retrieve data from.");
+        if (!in_array($part, array('attributes', 'query'))) {
+            throw new \RuntimeException("Invalid part to retrieve data from, has to be either 'attributes' or 'query'.");
         }
 
         if ($request->$part->has($param)) {

--- a/Resources/config/converters.xml
+++ b/Resources/config/converters.xml
@@ -8,11 +8,8 @@
         <parameter key="sensio_framework_extra.converter.listener.class">Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener</parameter>
         <parameter key="sensio_framework_extra.converter.manager.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager</parameter>
         <parameter key="sensio_framework_extra.converter.doctrine.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter</parameter>
-<<<<<<< HEAD
         <parameter key="sensio_framework_extra.converter.datetime.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DateTimeParamConverter</parameter>
-=======
         <parameter key="sensio_framework_extra.converter.object.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ObjectParamConverter</parameter>
->>>>>>> ObjectParamConverter
     </parameters>
 
     <services>
@@ -33,7 +30,7 @@
         </service>
 
         <service id="sensio_framework_extra.converter.object" class="%sensio_framework_extra.converter.object.class%">
-            <tag name="request.param_converter" priority="-255" converter="object" /><!-- has to be the very last one -->
+            <tag name="request.param_converter" priority="-10" name="object" />
         </service>
     </services>
 </container>

--- a/Resources/config/converters.xml
+++ b/Resources/config/converters.xml
@@ -8,7 +8,11 @@
         <parameter key="sensio_framework_extra.converter.listener.class">Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener</parameter>
         <parameter key="sensio_framework_extra.converter.manager.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager</parameter>
         <parameter key="sensio_framework_extra.converter.doctrine.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter</parameter>
+<<<<<<< HEAD
         <parameter key="sensio_framework_extra.converter.datetime.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DateTimeParamConverter</parameter>
+=======
+        <parameter key="sensio_framework_extra.converter.object.class">Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ObjectParamConverter</parameter>
+>>>>>>> ObjectParamConverter
     </parameters>
 
     <services>
@@ -26,6 +30,10 @@
 
         <service id="sensio_framework_extra.converter.datetime" class="%sensio_framework_extra.converter.datetime.class%">
             <tag name="request.param_converter" converter="datetime" />
+        </service>
+
+        <service id="sensio_framework_extra.converter.object" class="%sensio_framework_extra.converter.object.class%">
+            <tag name="request.param_converter" priority="-255" converter="object" /><!-- has to be the very last one -->
         </service>
     </services>
 </container>

--- a/Tests/Request/ParamConverter/ObjectParamConverterTest.php
+++ b/Tests/Request/ParamConverter/ObjectParamConverterTest.php
@@ -16,7 +16,9 @@ class ObjectParamConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testApply()
     {
-        $request = Request::create('/', 'POST', array('foo' => array('bar' => array('foo' => 1), 'baz' => '2012-07-21')));
+        $request = Request::create('/', 'POST');
+        $request->query->set('foo', array('bar' => array('foo' => 1), 'baz' => '2012-07-21'));
+
         $config  = $this->createConfiguration('foo', __NAMESPACE__ . '\\Foo');
 
         $this->converter->apply($request, $config);

--- a/Tests/Request/ParamConverter/ObjectParamConverterTest.php
+++ b/Tests/Request/ParamConverter/ObjectParamConverterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ObjectParamConverter;
+
+class ObjectParamConverterTest extends \PHPUnit_Framework_TestCase
+{
+    private $converter;
+
+    public function setUp()
+    {
+        $this->converter = new ObjectParamConverter();
+    }
+
+    public function testApply()
+    {
+        $request = Request::create('/', 'POST', array('foo' => array('bar' => array('foo' => 1), 'baz' => '2012-07-21')));
+        $config  = $this->createConfiguration('foo', __NAMESPACE__ . '\\Foo');
+
+        $this->converter->apply($request, $config);
+
+        $foo = $request->attributes->get('foo');
+        $this->assertInstanceOf(__NAMESPACE__ . '\\Foo', $foo);
+        $this->assertInstanceOf(__NAMESPACE__ . '\\Bar', $foo->bar);
+        $this->assertInstanceOf('DateTime', $foo->baz);
+        $this->assertEquals(1, $foo->bar->foo);
+    }
+
+    public function createConfiguration($name, $class, array $options = null)
+    {
+        $config = $this->getMock(
+            'Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface', array(
+            'getClass', 'getAliasName', 'getOptions', 'getName'
+        ));
+        if ($options !== null) {
+            $config->expects($this->once())
+                   ->method('getOptions')
+                   ->will($this->returnValue($options));
+        }
+        $config->expects($this->any())
+               ->method('getClass')
+               ->will($this->returnValue($class));
+        $config->expects($this->any())
+               ->method('getName')
+               ->will($this->returnValue($name));
+
+        return $config;
+    }
+}
+
+class Foo
+{
+    public $bar;
+    public $baz;
+
+    public function __construct(Bar $bar, \DateTime $baz)
+    {
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
+}
+
+class Bar
+{
+    public $foo;
+
+    public function __construct($foo)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/Tests/Request/ParamConverter/ObjectParamConverterTest.php
+++ b/Tests/Request/ParamConverter/ObjectParamConverterTest.php
@@ -30,23 +30,6 @@ class ObjectParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $foo->bar->foo);
     }
 
-    public function testApplyPartRequest()
-    {
-        $request = Request::create('/', 'POST');
-        $request->request->set('foo', array('bar' => array('foo' => 1), 'baz' => '2012-07-21'));
-
-        $config  = $this->createConfiguration('foo', __NAMESPACE__ . '\\Foo');
-        $config->expects($this->once())->method('getOptions')->will($this->returnValue(array('part' => 'request')));
-
-        $this->converter->apply($request, $config);
-
-        $foo = $request->attributes->get('foo');
-        $this->assertInstanceOf(__NAMESPACE__ . '\\Foo', $foo);
-        $this->assertInstanceOf(__NAMESPACE__ . '\\Bar', $foo->bar);
-        $this->assertInstanceOf('DateTime', $foo->baz);
-        $this->assertEquals(1, $foo->bar->foo);
-    }
-
     public function testApplySetState()
     {
         $request = Request::create('/', 'POST');

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.1.*",
-        "doctrine/common": ">=2.1,<2.4-dev"
+        "doctrine/common": ">=2.1,<2.4-dev",
+        "symfony/validator": "2.1.*"
     },
     "autoload": {
         "psr-0": { "Sensio\\Bundle\\FrameworkExtraBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.1.*",
-        "doctrine/common": ">=2.1,<2.4-dev",
-        "symfony/validator": "2.1.*"
+        "doctrine/common": ">=2.1,<2.4-dev"
     },
     "autoload": {
         "psr-0": { "Sensio\\Bundle\\FrameworkExtraBundle": "" }


### PR DESCRIPTION
Allows to convert user input into object graphs (request query). Use-case could be criteria/query objects or other lightweight objects that are not persistent.

See the documentation update for details on how this converter works and the security implications.
