### PR TITLE
[WIP] [ParamConverteers] DoctrineFormParamConverter

### DIFF
--- a/Request/ParamConverter/DoctrineFormParamConverter.php
+++ b/Request/ParamConverter/DoctrineFormParamConverter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Request;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+class DoctrineFormParamConverter extends DoctrineParamConverter
+{
+    private $formFactory;
+
+    public function __construct(ManagerRegistry $registry = null, FormFactoryInterface $formFactory = null)
+    {
+        parent::__construct($registry);
+        $this->formFactory = $formFactory;
+    }
+
+    public function apply(Request $request, ConfigurationInterface $configuration)
+    {
+        $options = $this->getOptions($configuration);
+        $key     = isset($options['id']) ? $options['id'] : 'id';
+
+        if ($request->attributes->has($key)) {
+            parent::apply($request, $configuration);
+        }
+
+        $data = $request->attributes->get($configuration->getName());
+
+        $form = $this->formFactory->create(
+            $options['form_type'],
+            $data,
+            isset($options['form_options']) ? $options['form_options'] : array()
+        );
+
+        $form->bind($request);
+
+        if ( ! $form->isValid()) {
+            throw new HttpException(400, $form->getErrorsAsString());
+        }
+
+        $request->attributes->set($configuration->getName(), $form->getData());
+
+        return true;
+    }
+
+    public function supports(ConfigurationInterface $configuration)
+    {
+        if (!$this->formFactory) {
+            return false;
+        }
+
+        $options = $this->getOptions($configuration);
+
+        if (!isset($options['form_type'])) {
+            return false;
+        }
+
+        return parent::supports($configuration);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.1.*",
+        "symfony/form": "*",
         "doctrine/common": ">=2.1,<2.4-dev"
     },
     "autoload": {


### PR DESCRIPTION
Converts a request into an object by binding the data through a form type.

UseCase: APIs

```
/**
 * @ParamConverter("user", options={"form_type": "user"})
 * @Method("POST")
 */
public function updateUser(User $user)
{
}
```

Several limitations:
- Not sure if throwing a  HttpException 400 with the errors is enough for API clients to work with.
- Does not work with HTML requests, as HTTP 400 cannot be "converted" into a response object of the format:
  
  ```
  array("data" => $form->getData(), "form" => $form->createView())
  ```

This would be the minimum necessary data to allow FrameworkExtraBundle to do its templating magic, but the param converters dont allow this.
