### PR TITLE
Fix error when using Symfony Routing component annotations

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -4,6 +4,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Routing;
 
 use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route as FrameworkExtraBundleRoute;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 
 /*
@@ -37,7 +38,7 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
     {
         // controller
         $classAnnot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass);
-        if ($classAnnot && $service = $classAnnot->getService()) {
+        if ($classAnnot instanceof FrameworkExtraBundleRoute && $service = $classAnnot->getService()) {
             $route->setDefault('_controller', $service.':'.$method->getName());
         } else {
             $route->setDefault('_controller', $class->getName().'::'.$method->getName());


### PR DESCRIPTION
Hi, i just go an error because i was using `Symfony\Component\Routing\Annotation\Route` instead of `Sensio\Bundle\FrameworkExtraBundle\Configuration\Route` for controller routing annotations.

Here's the commit detail:

> A controller using "Symfony\Component\Routing\Annotation\Route" instead of "Sensio\Bundle\FrameworkExtraBundle\Configuration\Route", with a prefix annotation on the class:
> 
> /**
> - @Route("/prefix")
>   */
>   class SomeController { }
> 
> would cause an error:
> 
> Fatal error: Call to undefined method Symfony\Component\Routing\Annotation\Route::getService() in /vendor/sensio/framework-extra-bundle/Sensio/Bundle/FrameworkExtraBundle/Routing/AnnotatedRouteControllerLoader.php on line 40
