### PR TITLE
[ParamConverter] Make DateTime converter work on attributes only.

### DIFF
--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -13,10 +13,11 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use DateTime;
 
 /**
- * Convert DateTime instances from request variables.
+ * Convert DateTime instances from request attribute variable.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
@@ -26,16 +27,19 @@ class DateTimeParamConverter implements ParamConverterInterface
     {
         $param = $configuration->getName();
 
-        if (!$request->get($param)) {
+        if (!$request->attributes->has($param)) {
             return false;
         }
 
         $options = $configuration->getOptions();
+        $value   = $request->attributes->get($param);
 
-        if (isset($options['format'])) {
-            $date = DateTime::createFromFormat($options['format'], $request->get($param));
-        } else {
-            $date = new DateTime($request->get($param));
+        $date = isset($options['format'])
+            ? DateTime::createFromFormat($options['format'], $value)
+            : new DateTime($value);
+
+        if (!$date) {
+            throw new NotFoundHttpException('Invalid date given.');
         }
 
         $request->attributes->set($param, $date);

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -28,9 +28,22 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testApply()
     {
-        $request = new Request(array('start' => '2012-07-21 00:00:00'));
+        $request = new Request(array(), array(), array('start' => '2012-07-21 00:00:00'));
         $config = $this->createConfiguration("DateTime", "start");
 
+        $this->converter->apply($request, $config);
+
+        $this->assertInstanceOf("DateTime", $request->attributes->get('start'));
+        $this->assertEquals('2012-07-21', $request->attributes->get('start')->format('Y-m-d'));
+    }
+
+    public function testApplyWithFormatInvalidDate404Exception()
+    {
+        $request = new Request(array(), array(), array('start' => '2012-07-21'));
+        $config = $this->createConfiguration("DateTime", "start");
+        $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'd.m.Y')));
+
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given.');
         $this->converter->apply($request, $config);
     }
 


### PR DESCRIPTION
Currently the DateTime converter works on all attributes. This can potentially pose problems, so this PR restricts the usage to attributes only. Additionally a 404 exception is thrown if a datetime cannot be converted succesfully.

Improved tests.
