### PR TITLE
[ParamConverter] Skip Request when resolving

### DIFF
--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -63,7 +63,7 @@ class ParamConverterListener
 
         // automatically apply conversion for non-configured objects
         foreach ($r->getParameters() as $param) {
-            if (!$param->getClass() || $param->isInstance($request)) {
+            if (!$param->getClass() || $param->getClass()->isInstance($request)) {
                 continue;
             }
 

--- a/Tests/EventListener/ParamConverterListenerTest.php
+++ b/Tests/EventListener/ParamConverterListenerTest.php
@@ -21,7 +21,7 @@ class ParamConverterListenerTest extends \PHPUnit_Framework_TestCase
                 ->with($this->equalTo($request), $this->equalTo(array()));
 
         $listener = new ParamConverterListener($manager);
-        $event    = new FilterControllerEvent($kernel, array($this, 'testRequestIsSkipped'), $request, null);
+        $event    = new FilterControllerEvent($kernel, array(new TestController(), 'execute'), $request, null);
 
         $listener->onKernelController($event);
     }


### PR DESCRIPTION
Skip Request when resolving. This improves performance since injecting the Request is already a feature of Symfony Core
