### PR TITLE
Surround @Cache annotation in quotes and fix comment typo

### DIFF
--- a/EventListener/CacheListener.php
+++ b/EventListener/CacheListener.php
@@ -15,8 +15,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 
 /**
- * The CacheListener class has the responsability to modify the
- * Response object when a controller uses the @Cache annotation.
+ * The CacheListener class has the responsibility to modify the
+ * Response object when a controller uses the "@Cache" annotation.
  *
  * @author     Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
Currently the unquoted @Cache string in CacheListener is causing an error. This PR fixes the issue.
