### PR TITLE
typo in ParamConverter doc

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -204,13 +204,14 @@ To register your converter service you must add a tag to your service
     .. code-block:: xml
 
         <service id="my_converter" class="MyBundle/Request/ParamConverter/MyConverter">
-            <tag name="request.param_converter" priority="-2" name="my_converter" />
+            <tag name="request.param_converter" priority="-2" converter="my_converter" />
         </service>
 
-You can register a converter by priority, by name or both. If you don't
-specifiy a priority or name the converter will be added to the converter stack
-with a priority of `0`. To explicitly disable the registration by priority you
-have to set `priority="false"` in your tag definition.
+You can register a converter by priority, by name (attribute "converter") or
+both. If you don't specifiy a priority or name the converter will be added to
+the converter stack with a priority of `0`. To explicitly disable the
+registration by priority you have to set `priority="false"` in your tag
+definition.
 
 .. tip::
 


### PR DESCRIPTION
Copying the example results in a DTD error when parsing the XML, as the attribute "name" is used twice.

The attribute should actually be called "converter" (see https://github.com/sensio/SensioFrameworkExtraBundle/blob/2.1/DependencyInjection/Compiler/AddParamConverterPass.php#L35)
