### PR TITLE
Fixed typo to render note block

### DIFF
--- a/Resources/doc/annotations/view.rst
+++ b/Resources/doc/annotations/view.rst
@@ -40,7 +40,7 @@ case for the above example, you can even omit the annotation value::
         return array('post' => $post);
     }
 
-..note::
+.. note::
 
     If you are using PHP as a templating system, you need to make it
     explicit::


### PR DESCRIPTION
There was a space missing between `..` and `note` which leads to a code block instead of a note.
