### PR TITLE
[WIP] embedded templates

### DIFF
--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -29,6 +29,13 @@ class Template extends ConfigurationAnnotation
     protected $template;
 
     /**
+     * The template used on non-master requests
+     *
+     * @var TemplateReference
+     */
+    protected $embeddedTemplate;
+
+    /**
      * The template engine used when a specific template isnt specified
      *
      * @var string
@@ -133,6 +140,22 @@ class Template extends ConfigurationAnnotation
     public function setTemplate($template)
     {
         $this->template = $template;
+    }
+
+    /**
+     * @param TemplateReference|string $template
+     */
+    public function setEmbeddedTemplate($template)
+    {
+        $this->embeddedTemplate = $template;
+    }
+
+    /**
+     * @return TemplateReference
+     */
+    public function getEmbeddedTemplate()
+    {
+        return $this->embeddedTemplate;
     }
 
     /**

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /*
  * This file is part of the Symfony framework.
@@ -110,6 +111,10 @@ class TemplateListener
 
         if (!$template = $request->attributes->get('_template')) {
             return $parameters;
+        }
+
+        if ($request->getRequestType() === HttpKernelInterface::SUB_REQUEST && !empty($parameters['embeddedTemplate'])) {
+            $template = $template->set('name', $parameters['embeddedTemplate'];
         }
 
         if (!$request->attributes->get('_template_streamable')) {


### PR DESCRIPTION
I'm looking for a way that different templates could be used depending if we're on a MASTER or SUB request.

This is useful when some pieces of the application could be either displayed in their own page, or embedded / rendered through for example: `{% render 'MyBundle:Controller:action %}`

Now we need to define 2 different actions in order only to pick the correct template.
