### PR TITLE
Documentation: Add information on how to activate annotated routes to main page

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -141,5 +141,7 @@ annotations::
     {
     }
 
+The routes need to be imported to be active as any other routing resources, see :doc:`Annotated Routes Activation<annotations/routing#activation>` for details.
+
 .. _`SensioFrameworkExtraBundle`: https://github.com/sensio/SensioFrameworkExtraBundle
 .. _`Download`: http://github.com/sensio/SensioFrameworkExtraBundle


### PR DESCRIPTION
Bundle review page should give a complete general idea on how to use annotated routing, but it doesn't say about how to activate (import) annotated routing. Developer had to read further to find required information before.
