### PR TITLE
Added possibility to set engine in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * added the possibility to configure the repository method to use for the
    Doctrine converter via the repository_method option.
+ * [BC break] Added the possibility to configure the default templating engine
+   in a configuration file.
 
 2.1
 ---

--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -33,7 +33,7 @@ class Template extends ConfigurationAnnotation
      *
      * @var string
      */
-    protected $engine = 'twig';
+    protected $engine;
 
     /**
      * The associative array of template variables.

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('annotations')->defaultTrue()->end()
+                        ->scalarNode('engine')->defaultValue('twig')->end()
                     ->end()
                 ->end()
                 ->arrayNode('cache')

--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -32,6 +32,8 @@ class SensioFrameworkExtraExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        $container->setParameter('sensio_framework_extra.view.engine', $config['view']['engine']);
+
         $annotationsToLoad = array();
 
         if ($config['router']['annotations']) {

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -58,6 +58,10 @@ class TemplateListener
         }
 
         if (!$configuration->getTemplate()) {
+            if (null === $configuration->getEngine()) {
+                $configuration->setEngine($this->container->getParameter('sensio_framework_extra.view.engine'));
+            }
+
             $guesser = $this->container->get('sensio_framework_extra.view.guesser');
             $configuration->setTemplate($guesser->guessTemplateName($controller, $request, $configuration->getEngine()));
         }

--- a/Resources/doc/annotations/view.rst
+++ b/Resources/doc/annotations/view.rst
@@ -53,6 +53,8 @@ case for the above example, you can even omit the annotation value::
             // ...
         }
 
+    This will override the default templating engine set in the configuration.
+
 And if the only parameters to pass to the template are method arguments, you
 can use the ``vars`` attribute instead of returning an array. This is very
 useful in combination with the ``@ParamConverter`` :doc:`annotation

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -37,7 +37,7 @@ The default configuration is as follow:
         sensio_framework_extra:
             router:  { annotations: true }
             request: { converters: true }
-            view:    { annotations: true }
+            view:    { annotations: true, engine: twig }
             cache:   { annotations: true }
 
     .. code-block:: xml
@@ -46,7 +46,7 @@ The default configuration is as follow:
         <sensio-framework-extra:config>
             <router annotations="true" />
             <request converters="true" />
-            <view annotations="true" />
+            <view annotations="true" engine="php" />
             <cache annotations="true" />
         </sensio-framework-extra:config>
 
@@ -56,12 +56,15 @@ The default configuration is as follow:
         $container->loadFromExtension('sensio_framework_extra', array(
             'router'  => array('annotations' => true),
             'request' => array('converters' => true),
-            'view'    => array('annotations' => true),
+            'view'    => array('annotations' => true, 'engine' => 'twig'),
             'cache'   => array('annotations' => true),
         ));
 
 You can disable some annotations and conventions by defining one or more
 settings to false.
+
+You can set the defult templating engine in the engine option. This will
+default to ``twig``.
 
 Annotations for Controllers
 ---------------------------


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: make it configurable per bundle, to remove the BC break (?)
License of the code: MIT
Documentation PR: -

This PR will add the possibility to configure the default templating engine in the configuration file by using the `sensio_framework_extra.view.engine` option.

If the engine set in the annotation (`@Template(engine="php")`), this value will be used.

I'm not sure if this is mergable, because it will break the BC. If a user sets the default engine to something different than `Twig`, the third-party bundles get problems because they don't expect this to happen. They need to include `engine="twig"` everywhere and that is just what this PR tries to minimalize.

One solution to avoid the BC break is to configure the bundles for which the default engine get changed, for instance:

```
sensio_framework_extra:
    view:
        engine:
            php: [AcmeDemoBundle, MyBundleThatUsesPhpAsADefaultBundle]
```
