### PR TITLE
Merge the ParamConverters on class level and the ParamConverters in method level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * added the possibility to configure the repository method to use for the
    Doctrine converter via the repository_method option.
+ * [BC break] When defining multiple @Cache, @Method or @Template annotations on
+   a controller class or method, the latter now overrules the former
 
 2.1
 ---

--- a/Configuration/Cache.php
+++ b/Configuration/Cache.php
@@ -168,4 +168,15 @@ class Cache extends ConfigurationAnnotation
     {
         return 'cache';
     }
+
+    /**
+     * Only one cache directive is allowed
+     *
+     * @return Boolean
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return false;
+    }
 }

--- a/Configuration/ConfigurationInterface.php
+++ b/Configuration/ConfigurationInterface.php
@@ -24,4 +24,11 @@ interface ConfigurationInterface
      * @return string
      */
     function getAliasName();
+
+    /**
+     * Returns whether multiple annotations of this type are allowed
+     *
+     * @return Boolean
+     */
+    function allowArray();
 }

--- a/Configuration/Method.php
+++ b/Configuration/Method.php
@@ -66,4 +66,15 @@ class Method extends ConfigurationAnnotation
     {
         return 'method';
     }
+
+    /**
+     * Only one cache directive is allowed
+     *
+     * @return Boolean
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return false;
+    }
 }

--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -176,4 +176,15 @@ class ParamConverter extends ConfigurationAnnotation
     {
         return 'converters';
     }
+
+    /**
+     * Multiple ParamConverters are allowed
+     *
+     * @return Boolean
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return true;
+    }
 }

--- a/Configuration/Route.php
+++ b/Configuration/Route.php
@@ -30,4 +30,15 @@ class Route extends BaseRoute
     {
         return $this->service;
     }
+
+    /**
+     * Multiple route annotations are allowed
+     *
+     * @return Boolean
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return true;
+    }
 }

--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -145,4 +145,15 @@ class Template extends ConfigurationAnnotation
     {
         return 'template';
     }
+
+    /**
+     * Only one template directive is allowed
+     *
+     * @return Boolean
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return false;
+    }
 }

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -59,13 +59,27 @@ class ControllerListener
         $classConfigurations  = $this->getConfigurations($this->reader->getClassAnnotations($object));
         $methodConfigurations = $this->getConfigurations($this->reader->getMethodAnnotations($method));
 
-        $configurations = array_merge($classConfigurations, $methodConfigurations);
+        $configurations = array();
+        foreach(array_merge(array_keys($classConfigurations), array_keys($methodConfigurations)) as $key) {
+            if (!array_key_exists($key, $classConfigurations)) {
+                $configurations[$key] = $methodConfigurations[$key];
+            } elseif (!array_key_exists($key, $methodConfigurations)) {
+                $configurations[$key] = $classConfigurations[$key];
+            } else {
+                if (is_array($classConfigurations[$key])) {
+                    if (!is_array($methodConfigurations[$key])) {
+                        throw new \UnexpectedValueException('Configurations should both be an array or both not be an array');
+                    }
+                    $configurations[$key] = array_merge($classConfigurations[$key], $methodConfigurations[$key]);
+                } else {
+                    // method configuration overrides class configuration
+                    $configurations[$key] = $methodConfigurations[$key];
+                }
+            }
+        }
 
         $request = $event->getRequest();
         foreach ($configurations as $key => $attributes) {
-            if (is_array($attributes) && count($attributes) == 1) {
-                $attributes = $attributes[0];
-            }
             $request->attributes->set($key, $attributes);
         }
     }
@@ -75,7 +89,11 @@ class ControllerListener
         $configurations = array();
         foreach ($annotations as $configuration) {
             if ($configuration instanceof ConfigurationInterface) {
-                $configurations['_'.$configuration->getAliasName()][] = $configuration;
+                if ($configuration->allowArray()) {
+                    $configurations['_'.$configuration->getAliasName()][] = $configuration;
+                } else {
+                    $configurations['_'.$configuration->getAliasName()] = $configuration;
+                }
             }
         }
 

--- a/Tests/EventListener/Fixture/FooControllerCacheAtClassAndMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerCacheAtClassAndMethod.php
@@ -10,11 +10,10 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 class FooControllerCacheAtClassAndMethod
 {
     const CLASS_SMAXAGE = 20;
-    const METHOD_SMAXAGE = 15;
-    const METHOD_SECOND_SMAXAGE = 25;
+    const METHOD_SMAXAGE = 25;
 
     /**
-     * @Cache(smaxage="15")
+     * @Cache(smaxage="25")
      */
     public function barAction()
     {

--- a/Tests/EventListener/Fixture/FooControllerParamConverterAtClassAndMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerParamConverterAtClassAndMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+/**
+ * @ParamConverter("test")
+ */
+class FooControllerParamConverterAtClassAndMethod
+{
+    /**
+     * @ParamConverter("test2")
+     */
+    public function barAction($test, $test2)
+    {
+    }
+}

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -51,7 +51,7 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->getMock(
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface', array(
-            'getClass', 'getAliasName', 'getOptions', 'getName',
+            'getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray'
         ));
         if ($name !== null) {
             $config->expects($this->any())

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -31,7 +31,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->getMock(
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface', array(
-            'getClass', 'getAliasName', 'getOptions', 'isOptional', 'getName',
+            'getClass', 'getAliasName', 'getOptions', 'isOptional', 'getName', 'allowArray'
         ));
         if ($options !== null) {
             $config->expects($this->once())


### PR DESCRIPTION
I have the following controller:

```
/**
 * Location controller.
 *
 * @Route("/approve/period/{period_id}", requirements={"period_id":"\d+"})
 * @ParamConverter("period", options={"id"="period_id"})
 */
class ApprovementController extends Controller
{

    /**
     * @Route("/department/{department_id}/approve", name="something", requirements={"department_id":"\d+"}, defaults={"_format":"json"}, options={"expose":true})
     * @ParamConverter("department", options={"id"="department_id"})
     */
    public function approveDayAction(Department $department, Period $period)
    {
        [...]
    }
}
```

The problem here is that due to the way the annotations are merged, the ParamConverter on class level was dropped, and overridden by that on method level, instead of merged into it's array.

As a workaround, I had to copy the class level annotation to the method level annotation
