### PR TITLE
Fix "service" parameter in @Route annotation not correctly parsed

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -38,7 +38,7 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
     {
         // controller
         $classAnnot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass);
-        if ($classAnnot instanceof FrameworkExtraBundleRoute && $service = $classAnnot->getService()) {
+        if ($annot instanceof FrameworkExtraBundleRoute && $service = $annot->getService()) {
             $route->setDefault('_controller', $service.':'.$method->getName());
         } else {
             $route->setDefault('_controller', $class->getName().'::'.$method->getName());


### PR DESCRIPTION
when defining a controller as a service and using the @Route annotation,  the "service" parameter of the annotation never parsed
