### PR TITLE
[DoctrineParamConverter] Added option to specify not found error message

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -52,7 +52,8 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
 
         if (null === $object && false === $configuration->isOptional()) {
-            throw new NotFoundHttpException(sprintf('%s object not found.', $class));
+            $errorMessage = isset($options["notFoundError"]) ? $options["notFoundError"] : '%s object not found.';
+            throw new NotFoundHttpException(sprintf($errorMessage, $class));
         }
 
         $request->attributes->set($name, $object);


### PR DESCRIPTION
The error message can now be added to the options array in the ParamConverter definition with the key `"notFoundError"`

Fixes #195
