### PR TITLE
[Route] Ensure @Route.service is not defined on methods (fix #192)

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -30,9 +30,12 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
      * Configures the _controller default parameter and eventually the _method
      * requirement of a given Route instance.
      *
-     * @param Route            $route  A Route instance
-     * @param ReflectionClass  $class  A ReflectionClass instance
-     * @param ReflectionMethod $method A ReflectionClass method
+     * @param Route             $route  A route instance
+     * @param \ReflectionClass  $class  A ReflectionClass instance
+     * @param \ReflectionMethod $method A ReflectionClass method
+     * @param mixed             $annot  The annotation class instance
+     *
+     * @throws \LogicException When the service option is specified on a method
      */
     protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
     {
@@ -48,6 +51,8 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
             if ($configuration instanceof Method) {
                 $route->setRequirement('_method', implode('|', $configuration->getMethods()));
+            } elseif ($configuration instanceof FrameworkExtraBundleRoute && $configuration->getService()) {
+                throw new \LogicException('The service option can only be specified at class level.');
             }
         }
     }
@@ -55,9 +60,10 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
     /**
      * Makes the default route name more sane by removing common keywords.
      *
-     * @param  ReflectionClass  $class  A ReflectionClass instance
-     * @param  ReflectionMethod $method A ReflectionMethod instance
-     * @return string
+     * @param  \ReflectionClass  $class  A ReflectionClass instance
+     * @param  \ReflectionMethod $method A ReflectionMethod instance
+     *
+     * @return string The default route name
      */
     protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
     {

--- a/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Routing;
+
+use \Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testServiceOptionIsAllowedOnClass()
+    {
+        $route = $this->getMockBuilder('Symfony\Component\Routing\Route')
+            ->setMethods(array('setDefault'))
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $route
+            ->expects($this->once())
+            ->method('setDefault')
+            ->with('_controller', 'service:testServiceOptionIsAllowedOnClass')
+        ;
+
+        $annotation = new Route(array());
+        $annotation->setService('service');
+
+        $reader = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+            ->setMethods(array('getClassAnnotation', 'getMethodAnnotations'))
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass()
+        ;
+
+        $reader
+            ->expects($this->once())
+            ->method('getClassAnnotation')
+            ->will($this->returnValue($annotation))
+        ;
+
+        $reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
+
+        $loader = $this->getMockBuilder('Sensio\Bundle\FrameworkExtraBundle\Routing\AnnotatedRouteControllerLoader')
+            ->setConstructorArgs(array($reader))
+            ->getMock()
+        ;
+
+        $r = new \ReflectionMethod($loader, 'configureRoute');
+        $r->setAccessible(true);
+
+        $r->invoke(
+            $loader,
+            $route,
+            new \ReflectionClass($this),
+            new \ReflectionMethod($this, 'testServiceOptionIsAllowedOnClass'),
+            null
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The service option can only be specified at class level.
+     */
+    public function testServiceOptionIsNotAllowedOnMethod()
+    {
+        $route = $this->getMockBuilder('Symfony\Component\Routing\Route')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $reader = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+            ->setMethods(array('getClassAnnotation', 'getMethodAnnotations'))
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass()
+        ;
+
+        $annotation = new Route(array());
+        $annotation->setService('service');
+
+        $reader
+            ->expects($this->once())
+            ->method('getClassAnnotation')
+            ->will($this->returnValue(null))
+        ;
+
+        $reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array($annotation)))
+        ;
+
+        $loader = $this->getMockBuilder('Sensio\Bundle\FrameworkExtraBundle\Routing\AnnotatedRouteControllerLoader')
+            ->setConstructorArgs(array($reader))
+            ->getMock()
+        ;
+
+        $r = new \ReflectionMethod($loader, 'configureRoute');
+        $r->setAccessible(true);
+
+        $r->invoke(
+            $loader,
+            $route,
+            new \ReflectionClass($this),
+            new \ReflectionMethod($this, 'testServiceOptionIsNotAllowedOnMethod'),
+            null
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes/no, throw an exception rather than silently ignore the service option |
| New feature? | yes, throw an exception rather than silently ignore the service option |
| BC breaks? | kind of if the configuration was wrong |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #192 |
| License | MIT |
| Doc PR | - |
