### PR TITLE
Remove ParamConverter annotation class from class map

### DIFF
--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -45,7 +45,6 @@ class SensioFrameworkExtraExtension extends Extension
             $annotationsToLoad[] = 'converters.xml';
 
             $this->addClassesToCompile(array(
-                'Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\ParamConverter',
                 'Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\ParamConverterListener',
                 'Sensio\\Bundle\\FrameworkExtraBundle\\Request\\ParamConverter\\DateTimeParamConverter',
                 'Sensio\\Bundle\\FrameworkExtraBundle\\Request\\ParamConverter\\DoctrineParamConverter',


### PR DESCRIPTION
Since 23daf05e2366f9257ef28356116644ea2947f420 is merged, I'm getting this error as soon as the class map is generated:

```
[Semantical Error] The class "Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter". If it is indeed no annotation, then you need to add @IgnoreAnnotation("ParamConverter") to the _class_ doc comment of class ProductConfigurator\ProductBundle\Controller\SliderController. 
```

This is because the class is compiled without annotations, so also without the @Annotation annotation
