### PR TITLE
[DoctrineParamConverter] Handling of null attributes

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -36,7 +36,7 @@ class DoctrineParamConverter implements ParamConverterInterface
 
     /**
      * @{inheritdoc}
-     * 
+     *
      * @throws \LogicException       When unable to guess how to get a Doctrine instance from the request information
      * @throws NotFoundHttpException When object not found
      */
@@ -143,6 +143,10 @@ class DoctrineParamConverter implements ParamConverterInterface
             }
         }
 
+        if ($options['strip_null']) {
+            $criteria = array_filter($criteria, function ($value) { return !is_null($value); });
+        }
+
         if (!$criteria) {
             return false;
         }
@@ -191,6 +195,7 @@ class DoctrineParamConverter implements ParamConverterInterface
             'entity_manager' => null,
             'exclude'        => array(),
             'mapping'        => array(),
+            'strip_null'     => false,
         ), $configuration->getOptions());
     }
 

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -82,6 +82,37 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($request->attributes->get('arg'));
     }
 
+    public function testApplyWithStripNulls()
+    {
+        $request = new Request();
+        $request->attributes->set('arg', null);
+        $config = $this->createConfiguration('stdClass', array('mapping' => array('arg' => 'arg'), 'strip_null' => true), 'arg', true);
+
+        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $manager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $manager->expects($this->once())
+            ->method('getClassMetadata')
+            ->with('stdClass')
+            ->will($this->returnValue($classMetadata));
+
+        $manager->expects($this->never())
+            ->method('getRepository');
+
+        $this->registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->with('stdClass')
+            ->will($this->returnValue($manager));
+
+        $classMetadata->expects($this->once())
+            ->method('hasField')
+            ->with($this->equalTo('arg'))
+            ->will($this->returnValue(true));
+
+        $this->converter->apply($request, $config);
+
+        $this->assertNull($request->attributes->get('arg'));
+    }
+
     /**
      * @dataProvider idsProvider
      */


### PR DESCRIPTION
I've run into an issue with the ParamConverter and how it handles null values when using custom mappings.

I've got an entity that has a property that can be null, and when using the ParamConverter, if a value is not supplied I am getting back one of the entities with a null field, when I was expecting the ParamConverter to return null instead of an object.

Given that the behaviour has been like this since the beginning, I added an option to the DoctrineParamConverter, `strip_null` that will strip any null attributes from the $criteria array, with an accompanied test.
