### PR TITLE
[Template] Added lowercaseName option

### DIFF
--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -50,6 +50,13 @@ class Template extends ConfigurationAnnotation
     protected $streamable = false;
 
     /**
+     * Should the template name be lowercased,underscored?
+     *
+     * @var Boolean
+     */
+    protected $lowercaseName = false;
+
+    /**
      * Returns the array of templates variables.
      *
      * @return array
@@ -73,6 +80,22 @@ class Template extends ConfigurationAnnotation
     public function isStreamable()
     {
         return (Boolean) $this->streamable;
+    }
+
+    /**
+     * @param Boolean $lowercaseName
+     */
+    public function setLowercaseName($lowercaseName)
+    {
+        $this->lowercaseName = $lowercaseName;
+    }
+
+    /**
+     * @return Boolean
+     */
+    public function isLowercaseName()
+    {
+        return (Boolean) $this->lowercaseName;
     }
 
     /**

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -61,7 +61,7 @@ class TemplateListener implements EventSubscriberInterface
 
         if (!$configuration->getTemplate()) {
             $guesser = $this->container->get('sensio_framework_extra.view.guesser');
-            $configuration->setTemplate($guesser->guessTemplateName($controller, $request, $configuration->getEngine()));
+            $configuration->setTemplate($guesser->guessTemplateName($controller, $request, $configuration->getEngine(), $configuration->isLowercaseName()));
         }
 
         $request->attributes->set('_template', $configuration->getTemplate());

--- a/Templating/TemplateGuesser.php
+++ b/Templating/TemplateGuesser.php
@@ -45,10 +45,11 @@ class TemplateGuesser
      * @param  array                     $controller An array storing the controller object and action method
      * @param  Request                   $request    A Request instance
      * @param  string                    $engine
+     * @param  boolean                   $lowercaseName
      * @return TemplateReference         template reference
      * @throws \InvalidArgumentException
      */
-    public function guessTemplateName($controller, Request $request, $engine = 'twig')
+    public function guessTemplateName($controller, Request $request, $engine = 'twig', $lowercaseName = false)
     {
         $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
 
@@ -57,6 +58,10 @@ class TemplateGuesser
         }
         if (!preg_match('/^(.+)Action$/', $controller[1], $matchAction)) {
             throw new \InvalidArgumentException(sprintf('The "%s" method does not look like an action method (it does not end with Action)', $controller[1]));
+        }
+
+        if ($lowercaseName) {
+            $matchAction[1] = strtolower(preg_replace('!([a-z\d])([A-Z])!', '$1_$2', $matchAction[1]));
         }
 
         $bundle = $this->getBundleForClass($className);

--- a/Tests/Templating/TemplateGuesserTest.php
+++ b/Tests/Templating/TemplateGuesserTest.php
@@ -83,6 +83,21 @@ class TemplateGuesserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FooBundle:FooBar:index.html.twig', (string) $templateReference);;
     }
 
+    public function testGuessTemplateNameLowercased()
+    {
+        $this->kernel
+            ->expects($this->never())
+            ->method('getBundle');
+
+        $templateGuesser = new TemplateGuesser($this->kernel);
+        $templateReference = $templateGuesser->guessTemplateName(array(
+            new Fixture\FooBundle\Controller\FooController(),
+            'fooBarAction',
+        ), new Request(), 'twig', true);
+
+        $this->assertEquals('FooBundle:Foo:foo_bar.html.twig', (string) $templateReference);
+    }
+
     protected function getBundle($name, $namespace, $parent = null)
     {
         $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');


### PR DESCRIPTION
Can we merge this? here''s summary

Often controller actions named as `viewSummaryAction()` or `viewSomething()`
but desired twig template names are `view_summary.html.twig` and `view_something.html.twig` but with current @Template it seems not possible to achieve this (except full template path like @Template(FooBarBundle:Controller:view_summary.html.twig))

so, `@Template(lowercaseName=true)` will do all work above, I think idea is clear.
Thanks
