### PR TITLE
Added autoloading information

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -22,6 +22,12 @@ Then, like for any other bundle, include it in your Kernel class::
         ...
     }
 
+If you plan to use or create annotations for controllers, make sure to update
+your ``autoload.php`` by adding the following line::
+
+    Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+
+
 Configuration
 -------------
 


### PR DESCRIPTION
When using the annotations of this bundle, one has to update the autoloader. Same when creating custom annotations.

The needed line is present in the SE `autoload.php` file, but should be added when not using the SE. For instance, when setting up a demo app for bundle testing with Behat.
