### PR TITLE
Added public="true" to @Cache annotation examples

### DIFF
--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -9,7 +9,7 @@ The ``@Cache`` annotation makes it easy to define HTTP caching::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
     /**
-     * @Cache(expires="tomorrow")
+     * @Cache(expires="tomorrow", public="true")
      */
     public function indexAction()
     {
@@ -18,7 +18,7 @@ The ``@Cache`` annotation makes it easy to define HTTP caching::
 You can also use the annotation on a class to define caching for all methods::
 
     /**
-     * @Cache(expires="tomorrow")
+     * @Cache(expires="tomorrow", public="true")
      */
     class BlogController extends Controller
     {
@@ -52,6 +52,7 @@ Annotation                     Response Method
 ``@Cache(smaxage="15")``       ``$response->setSharedMaxAge()``
 ``@Cache(maxage="15")``        ``$response->setMaxAge()``
 ``@Cache(vary=["Cookie"])``    ``$response->setVary()``
+``@Cache(public="true")``      ``$response->setPublic()``
 ============================== ===============
 
 .. note::


### PR DESCRIPTION
I spent a while trying to work out why my @Cache annotation wasn't having any effect, until I realised that the response wasn't being marked as public.

I've slightly modified the docs to add public="true" to the first couple of examples, and added public to the attributes table. This makes the first two examples "Just Work" by default.
