### PR TITLE
Update index.rst

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -148,8 +148,9 @@ annotations::
     }
 
 The routes need to be imported to be active as any other routing resources,
-see :ref:`Annotated Routes Activation<frameworkextra-annotations-routing-activation>` for
+see `Annotated Routes Activation`_ for
 details.
 
 .. _`SensioFrameworkExtraBundle`: https://github.com/sensio/SensioFrameworkExtraBundle
 .. _`Download`: http://github.com/sensio/SensioFrameworkExtraBundle
+.. _`Annotated Routes Activation`: annotations/routing.rst#activation


### PR DESCRIPTION
The current link for "Annotated Routes Activation" may be correct according to RST syntax, but in practice it just does not work both at github and at the current live (html) docs:

https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/Resources/doc/index.rst

http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
