### PR TITLE
[DateTimeParamConverter] Allow empty attributes

### DIFF
--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -39,6 +39,10 @@ class DateTimeParamConverter implements ParamConverterInterface
         $options = $configuration->getOptions();
         $value   = $request->attributes->get($param);
 
+        if (!$value and $configuration->isOptional()) {
+            return false;
+        }
+
         $date = isset($options['format'])
             ? DateTime::createFromFormat($options['format'], $value)
             : new DateTime($value);

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -47,11 +47,25 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->converter->apply($request, $config);
     }
 
+    public function testApplyOptionalWithEmptyAttribute()
+    {
+        $request = new Request(array(), array(), array('start' => ''));
+        $config = $this->createConfiguration('DateTime', 'start');
+        $config->expects($this->once())
+            ->method('isOptional')
+            ->will($this->returnValue(true));
+
+        $result = $this->converter->apply($request, $config);
+
+        $this->assertFalse($result);
+        $this->assertEquals('', $request->attributes->get('start'));
+    }
+
     public function createConfiguration($class = null, $name = null)
     {
         $config = $this->getMock(
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface', array(
-            'getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray'
+            'getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray', 'isOptional'
         ));
         if ($name !== null) {
             $config->expects($this->any())


### PR DESCRIPTION
If you have an empty attribute for a DateTime converter and it is optional, it shouldnt throw a 404 but abort the conversion.
