### PR TITLE
[Docs] Minor fixes: Typos, Formatting, Links, Sample code

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -54,7 +54,7 @@ To detect which converter is run on a parameter the following process is run:
 Built-in Converters
 -------------------
 
-The bundle has two built-in converter, the Doctrine one and a DateTime
+The bundle has two built-in converters, the Doctrine one and a DateTime
 converter.
 
 Doctrine Converter
@@ -65,7 +65,7 @@ Converter Name: ``doctrine.orm``
 The Doctrine Converter attempts to convert request attributes to Doctrine
 entities fetched from the database. Two different approaches are possible:
 
-- Fetch object by primary key
+- Fetch object by primary key.
 - Fetch object by one or several fields which contain unique values in the
   database.
 
@@ -117,7 +117,7 @@ This also allows you to have multiple converters in one action::
     {
     }
 
-In the example above, the post parameter is handled automatically, but the comment is 
+In the example above, the ``$post`` parameter is handled automatically, but ``$comment`` is
 configured with the annotation since they can not both follow the default convention.
 
 If you want to match an entity using multiple fields use the ``mapping`` hash
@@ -185,8 +185,7 @@ is accepted. You can be stricter with input given through the options::
 Creating a Converter
 --------------------
 
-All converters must implement the
-:class:`Sensio\\Bundle\\FrameworkExtraBundle\\Request\\ParamConverter\\ParamConverterInterface`::
+All converters must implement the ``ParamConverterInterface``::
 
     namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
 
@@ -208,14 +207,14 @@ The ``ParamConverter`` instance has three information about the annotation:
 * ``name``: The attribute name;
 * ``class``: The attribute class name (can be any string representing a class
   name);
-* ``options``: An array of options
+* ``options``: An array of options.
 
 The ``apply()`` method is called whenever a configuration is supported. Based
 on the request attributes, it should set an attribute named
 ``$configuration->getName()``, which stores an object of class
 ``$configuration->getClass()``.
 
-To register your converter service you must add a tag to your service
+To register your converter service you must add a tag to your service:
 
 .. configuration-block::
 

--- a/Resources/doc/annotations/routing.rst
+++ b/Resources/doc/annotations/routing.rst
@@ -4,7 +4,7 @@
 Usage
 -----
 
-The @Route annotation maps a route pattern with a controller::
+The ``@Route`` annotation maps a route pattern with a controller::
 
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
@@ -25,7 +25,7 @@ URL. This is equivalent to the following YAML configuration:
 .. code-block:: yaml
 
     blog_home:
-        pattern:  /
+        path:     /
         defaults: { _controller: SensioBlogBundle:Post:index }
 
 Like any route pattern, you can define placeholders, requirements, and default

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -122,7 +122,7 @@ This example shows all the available annotations in action::
          * @Route("/{id}")
          * @Method("GET")
          * @ParamConverter("post", class="SensioBlogBundle:Post")
-         * @Template("SensioBlogBundle:Annot:post.html.twig", vars={"post"})
+         * @Template("SensioBlogBundle:Annot:show.html.twig", vars={"post"})
          * @Cache(smaxage="15")
          */
         public function showAction(Post $post)


### PR DESCRIPTION
- The API link for `ParamConverterInterface` did not work so I've removed it
- In the overall annotation code example I've changed the template name `post.html.twig` to `show.html.twig` so the following statement in the doc becomes true: _As the `showAction` method follows some conventions, you can omit some annotations:_
