### PR TITLE
Ability to set template from route

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -82,7 +82,9 @@ class ControllerListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
         foreach ($configurations as $key => $attributes) {
-            $request->attributes->set($key, $attributes);
+            if (!$request->attributes->has($key)) {
+                $request->attributes->set($key, $attributes);
+            }
         }
     }
 

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -59,6 +59,10 @@ class TemplateListener implements EventSubscriberInterface
             return;
         }
 
+        if (is_string($configuration)) {
+            return;
+        }
+
         if (!$configuration->getTemplate()) {
             $guesser = $this->container->get('sensio_framework_extra.view.guesser');
             $configuration->setTemplate($guesser->guessTemplateName($controller, $request, $configuration->getEngine()));


### PR DESCRIPTION
I want set template from route, if I use Template() annotation, something like this:

product:
    path:      /{productUri}-awesome.html
    defaults:
        _controller: 'Bundle:Product:show'
        _template: 'Bundle:Product:showAwesome.html.twig'

This can be realized via params, but this needed checks in controller - if we have this param - we must render this template and so on. Not so friendly and flexible.

There is small patch. I'm new at Symfony world, can you review it and say can it be applied or if not, why?

Thanks
