### PR TITLE
[Minor bugfix] A boolean is expected. 

### DIFF
--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -100,7 +100,7 @@ Annotation                                            Response Method
 ``@Cache(smaxage="15")``                              ``$response->setSharedMaxAge()``
 ``@Cache(maxage="15")``                               ``$response->setMaxAge()``
 ``@Cache(vary={"Cookie"})``                           ``$response->setVary()``
-``@Cache(public="true")``                             ``$response->setPublic()``
+``@Cache(public=true)``                               ``$response->setPublic()``
 ``@Cache(lastModified="post.getUpdatedAt()")``        ``$response->setLastModified()``
 ``@Cache(ETag="post.getId() ~ post.getUpdatedAt()")`` ``$response->setETag()``
 ===================================================== ================================


### PR DESCRIPTION
Public="false" will be interpreted as true (since it is a string).

This change shows that you should not use quotes. 
