### PR TITLE
Allow cache on 301, 302, 404, 410 HTTP Codes

### DIFF
--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -88,7 +88,7 @@ class HttpCacheListener implements EventSubscriberInterface
 
         $response = $event->getResponse();
 
-        if (!$response->isSuccessful()) {
+        if (!$response->isSuccessful() && !$response->isCacheable()) {
             return;
         }
 


### PR DESCRIPTION
Hi,

I got a surprising behaviour when i wanted to use cache annotation for an HTTP301, after some investigation, i found that only 2xx HTTP codes were able to be cached.

This PR allow to cache further HTTP codes.

Thanks
