### PR TITLE
[ParamConverter] Allow DoctrineParamConverter to be provided a global default Entity Manager name

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -29,9 +29,16 @@ class DoctrineParamConverter implements ParamConverterInterface
      */
     protected $registry;
 
+    protected $defaultManagerName;
+
     public function __construct(ManagerRegistry $registry = null)
     {
         $this->registry = $registry;
+    }
+
+    public function setDefaultManagerName($defaultManagerName = null)
+    {
+        $this->defaultManagerName = $defaultManagerName;
     }
 
     /**
@@ -205,6 +212,10 @@ class DoctrineParamConverter implements ParamConverterInterface
 
     private function getManager($name, $class)
     {
+        if (null === $name) {
+            $name = $this->defaultManagerName;
+        }
+
         if (null === $name) {
             return $this->registry->getManagerForClass($class);
         }

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -366,4 +366,34 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($ret, "Should be supported");
     }
+
+    public function testSupportsWithGlobalDefaultEntityManager()
+    {
+        $config = $this->createConfiguration('stdClass', array());
+        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $metadataFactory->expects($this->once())
+                        ->method('isTransient')
+                        ->with($this->equalTo('stdClass'))
+                        ->will($this->returnValue( false ));
+
+        $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager->expects($this->once())
+                      ->method('getMetadataFactory')
+                      ->will($this->returnValue($metadataFactory));
+
+        $this->registry->expects($this->once())
+                    ->method('getManagers')
+                    ->will($this->returnValue(array($objectManager)));
+
+        $this->registry->expects($this->once())
+                      ->method('getManager')
+                      ->with('foo')
+                      ->will($this->returnValue($objectManager));
+
+        $this->converter->setDefaultManagerName('foo');
+
+        $ret = $this->converter->supports($config);
+
+        $this->assertTrue($ret, "Should be supported using 'foo' Entity Manager");
+    }
 }


### PR DESCRIPTION
The current implementation of DoctrineParamConverter allows to specify an entity_manager to use on a per-ParamConverter basis, but most of the time, the wanted behaviour is to specify it globally.

My use case for this is as follows:
I have to Object Managers (actually working with the MongoDB ODM here, but that doesn't matter), some classes are mapped by both and the mapper doesn't use the right one (i.e. the one I would want, most of the time). I would thus like to be able to specify a default object manager name across my application.

This PR allow to do so using via Dependency Injection. It's use is optional and does not impact the previous behaviour in any way (except an additional assignment and a test which seem negligible).

I also provided an additional test-case for the new behaviour.

If you think my PR could be improved in any way, please let me know.
