### PR TITLE
Add use statement for FramewordExtraBundle\configuration\cache

### DIFF
--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
 /*
  * This file is part of the Symfony framework.


### PR DESCRIPTION
since a few times, cache declaration is missing in httpCacheListener, this fixes the issues #274

https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/274
