### PR TITLE
Extending securiry expression language

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,6 +53,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('annotations')->defaultTrue()->end()
+                        ->scalarNode('expression_language')->defaultValue('sensio_framework_extra.security.expression_language.default')->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -74,6 +74,9 @@ class SensioFrameworkExtraExtension extends Extension
         if ($config['security']['annotations']) {
             $annotationsToLoad[] = 'security.xml';
 
+            $container->setAlias('sensio_framework_extra.security.expression_language', $config['security']['expression_language']);
+            $container->getAlias('sensio_framework_extra.security.expression_language')->setPublic(false);
+
             $this->addClassesToCompile(array(
                 'Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\SecurityListener',
             ));

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -13,6 +13,6 @@
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="sensio_framework_extra.security.expression_language" class="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" public="false" />
+        <service id="sensio_framework_extra.security.expression_language.default" class="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" public="false" />
     </services>
 </container>

--- a/Tests/DependencyInjection/SensioFrameworkExtraExtensionTest.php
+++ b/Tests/DependencyInjection/SensioFrameworkExtraExtensionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\DependencyInjection;
+
+use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\SensioFrameworkExtraExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class SensioFrameworkExtraExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $configuration;
+
+    public function setUp()
+    {
+        $this->configuration = new ContainerBuilder();
+    }
+
+    public function tearDown()
+    {
+        $this->configuration = null;
+    }
+
+    public function testDefaultExpressionLanguageConfig()
+    {
+        $loader = new SensioFrameworkExtraExtension();
+        $loader->load(array(), $this->configuration);
+
+        $this->assertAlias('sensio_framework_extra.security.expression_language.default', 'sensio_framework_extra.security.expression_language');
+    }
+
+    public function testOverrideExpressionLanguageConfig()
+    {
+        $loader = new SensioFrameworkExtraExtension();
+        $config = array(
+            'security'  => array(
+                'expression_language' => 'acme.security.expression_language'
+            )
+        );
+
+        $this->configuration->setDefinition('acme.security.expression_language', new Definition());
+
+        $loader->load(array($config), $this->configuration);
+
+        $this->assertAlias('acme.security.expression_language', 'sensio_framework_extra.security.expression_language');
+    }
+
+    /**
+     * @param string $value
+     * @param string $key
+     */
+    private function assertAlias($value, $key)
+    {
+        $this->assertEquals($value, (string) $this->configuration->getAlias($key), sprintf('%s alias is correct', $key));
+    }
+}


### PR DESCRIPTION
Allows extending default expression language in a @Security annotation.
