### PR TITLE
Update ParamConverterInterface example

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -189,14 +189,14 @@ All converters must implement the ``ParamConverterInterface``::
 
     namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
     use Symfony\Component\HttpFoundation\Request;
 
     interface ParamConverterInterface
     {
-        function apply(Request $request, ConfigurationInterface $configuration);
+        public function apply(Request $request, ParamConverter $configuration);
 
-        function supports(ConfigurationInterface $configuration);
+        public function supports(ParamConverter $configuration);
     }
 
 The ``supports()`` method must return ``true`` when it is able to convert the


### PR DESCRIPTION
The example is out of date, as the type hinting has changed in this [commit](https://github.com/sensiolabs/SensioFrameworkExtraBundle/commit/79ce337d9d1f1592eb276e113a5c1ebad68a2e70)
