### PR TITLE
Add missing use for @Cache annotations in HttpCacheListener

### DIFF
--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
 /*
  * This file is part of the Symfony framework.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This patch will fix this error:

``` bash
[Semantical Error] The annotation "@Cache" in class Sensio\Bundle\FrameworkExtraBundle\EventListener\HttpCacheListener was never imported. Did you maybe forget to add a "use" statement for this annotation?
```

I fix this like by adding the use statement like `Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener` but I don't know if it's not better to modify the docblock and add double quotes around the annotation.
