### PR TITLE
[FIX][ParamConverter] Fixed interface class

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -189,14 +189,14 @@ All converters must implement the ``ParamConverterInterface``::
 
     namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
     use Symfony\Component\HttpFoundation\Request;
 
     interface ParamConverterInterface
     {
-        function apply(Request $request, ConfigurationInterface $configuration);
+        function apply(Request $request, ParamConverter $configuration);
 
-        function supports(ConfigurationInterface $configuration);
+        function supports(ParamConverter $configuration);
     }
 
 The ``supports()`` method must return ``true`` when it is able to convert the


### PR DESCRIPTION
There was a deprecated parameter in two methods - `apply` and `supports` - `Configuration`. It should be `ParamConverter`

You can find it at https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/Request/ParamConverter/ParamConverterInterface.php?source=c - line 33
