### PR TITLE
Update cache.rst

### DIFF
--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -12,7 +12,7 @@ The ``@Cache`` annotation makes it easy to define HTTP caching::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
     /**
-     * @Cache(expires="tomorrow", public="true")
+     * @Cache(expires="tomorrow", public=true)
      */
     public function indexAction()
     {
@@ -22,7 +22,7 @@ You can also use the annotation on a class to define caching for all actions
 of a controller::
 
     /**
-     * @Cache(expires="tomorrow", public="true")
+     * @Cache(expires="tomorrow", public=true)
      */
     class BlogController extends Controller
     {


### PR DESCRIPTION
The value for the `public` attribute should be specified without quotation marks. For the construction `public="false"`, actually `public` takes the value `true`, because a string converted to Boolean will always be `true`.
