### PR TITLE
Don't extend controller

### DIFF
--- a/Resources/doc/annotations/routing.rst
+++ b/Resources/doc/annotations/routing.rst
@@ -173,7 +173,7 @@ PostController()`` itself::
     /**
      * @Route(service="my_post_controller_service")
      */
-    class PostController extends Controller
+    class PostController
     {
         // ...
     }


### PR DESCRIPTION
I think extending controller is not useful in this case. The service is fetched from the DI and will not contain the container if you don't inject it, right?
