### PR TITLE
Allow custom exception message for @Security annotation

### DIFF
--- a/Configuration/Security.php
+++ b/Configuration/Security.php
@@ -20,6 +20,17 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
 class Security extends ConfigurationAnnotation
 {
     protected $expression;
+    protected $message;
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
 
     public function getExpression()
     {

--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -54,7 +54,7 @@ class SecurityListener implements EventSubscriberInterface
         }
 
         if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {
-            throw new AccessDeniedException(sprintf('Expression "%s" denied access.', $configuration->getExpression()));
+            throw new AccessDeniedException($configuration->getMessage() ?: sprintf('Expression "%s" denied access.', $configuration->getExpression()));
         }
     }
 

--- a/Resources/doc/annotations/security.rst
+++ b/Resources/doc/annotations/security.rst
@@ -11,7 +11,7 @@ The ``@Security`` annotation restricts access on controllers::
     class PostController extends Controller
     {
         /**
-         * @Security("has_role('ROLE_ADMIN')")
+         * @Security("has_role('ROLE_ADMIN')", message="Staff only.")
          */
         public function indexAction()
         {
@@ -39,6 +39,16 @@ passed to the controller::
      */
     public function showAction(Post $post)
     {
+    }
+
+The message parameter allows you to customize the text shown to the user at the exception or error pages::
+
+    /**
+     * @Security("is_granted('POST_SHOW', post)",message="You have no rights to view this post.")
+     */
+    public function showAction(Post $post)
+    {
+
     }
 
 .. note::

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -135,7 +135,7 @@ This example shows all the available annotations in action::
          * @ParamConverter("post", class="SensioBlogBundle:Post")
          * @Template("SensioBlogBundle:Annot:show.html.twig", vars={"post"})
          * @Cache(smaxage="15", lastmodified="post.getUpdatedAt()", etag="'Post' ~ post.getId() ~ post.getUpdatedAt()")
-         * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)")
+         * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)", message="You have no access to this post")
          */
         public function showAction(Post $post)
         {


### PR DESCRIPTION
Custom exception messages are essential to generate customized exception and error page views. Default message is not always acceptable to be displayed to the end user at least because of disclosing security expression used to restrict access.