### PR TITLE
Fixed the compiled version of the is_granted expression function

### DIFF
--- a/Security/ExpressionLanguage.php
+++ b/Security/ExpressionLanguage.php
@@ -24,8 +24,8 @@ class ExpressionLanguage extends BaseExpressionLanguage
     {
         parent::registerFunctions();
 
-        $this->register('is_granted', function ($attributes, $object = null) {
-            return '$security_context->isGranted($attributes, $object)';
+        $this->register('is_granted', function ($attributes, $object = 'null') {
+            return sprintf('$security_context->isGranted(%s, %s)', $attributes, $object);
         }, function (array $variables, $attributes, $object = null) {
             return $variables['security_context']->isGranted($attributes, $object);
         });


### PR DESCRIPTION
In the compiled closure, the `$attributes` and `$object` arguments are the source code to build the argument. The current code ignores them entirely, and always evaluate the permissions on the `$attributes` and `$object` variables (which may not exist, at least for `$attributes`).

This does not impact the bundle because it never compiles the expressions but always runs them in evaluation mode (needed as knowing the request attributes keys would be hard to compile the expression earlier). But it is important for one of the reference bundles to implement the compilation closure properly (the Symfony doc got it wrong until recently, probably because the first places using it were wrong)
