### PR TITLE
Use HTTP_* constants instead of magic numbers

### DIFF
--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -89,7 +89,15 @@ class HttpCacheListener implements EventSubscriberInterface
 
         $response = $event->getResponse();
 
-        if (!in_array($response->getStatusCode(), array(200, 203, 300, 301, 302, 404, 410))) {
+        if (!in_array($response->getStatusCode(), array(
+            Response::HTTP_OK,
+            Response::HTTP_NON_AUTHORITATIVE_INFORMATION,
+            Response::HTTP_MULTIPLE_CHOICES,
+            Response::HTTP_MOVED_PERMANENTLY,
+            Response::HTTP_FOUND,
+            Response::HTTP_NOT_FOUND,
+            Response::HTTP_GONE
+        ))) {
             return;
         }
 


### PR DESCRIPTION
As of version 2.4 of the http-foundation, the Response contains constants that contain the status numbers. I've patched this line to use those constants instead of magic numbers when I came across this.
