### PR TITLE
add warning to feature descriptions being incompatible with Symfony 2.3 and earlier

### DIFF
--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -52,6 +52,12 @@ configuration, the latter overrides the former::
 HTTP Validation Strategies
 --------------------------
 
+.. caution::
+
+    Support for HTTP validation strategies was introduced in SensioFrameworkExtraBundle
+    3.0. This bundle version can only be used with Symfony 2.4 or later (see
+    :ref:`the SensioFrameworkExtraBundle release cycle <release-cycle-note>`).
+
 The ``lastModified`` and ``ETag`` attributes manages the HTTP validation cache
 headers. ``lastModified`` adds a ``Last-Modified`` header to Responses and
 ``ETag`` adds an ``ETag`` header.

--- a/Resources/doc/annotations/security.rst
+++ b/Resources/doc/annotations/security.rst
@@ -1,6 +1,12 @@
 @Security
 =========
 
+.. caution::
+
+    The ``@Security`` annotation was introduced in SensioFrameworkExtraBundle
+    3.0. This bundle version can only be used with Symfony 2.4 or later (see
+    :ref:`the SensioFrameworkExtraBundle release cycle <release-cycle-note>`).
+
 Usage
 -----
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -27,6 +27,18 @@ Then, like for any other bundle, include it in your Kernel class::
         ...
     }
 
+.. _release-cycle-note:
+
+.. note::
+
+    Since SensioFrameworkExtraBundle 3.0 its release cycle is out of sync
+    with Symfony's release cycle. This means that you can simply require
+    ``sensio/framework-extra-bundle: ~3.0`` in your ``composer.json`` file
+    and Composer will automatically pick the latest bundle version for you.
+    You have to use Symfony 2.4 or later for this workflow. Before Symfony
+    2.4, the required version of the SensioFrameworkExtraBundle should be
+    the same as your Symfony version.
+
 If you plan to use or create annotations for controllers, make sure to update
 your ``autoload.php`` by adding the following line::
 


### PR DESCRIPTION
Since the documentation on symfony.com renders the same SensioFrameworkExtraBundle documentation for each Symfony version, there are descriptions visible for Symfony versions prior to 2.4 that cannot be used (SensioFrameworkExtraBundle 3.0 and newer require Symfony 2.4 or higher).

This was reported to the Symfony repository (see symfony/symfony#11599).
