### PR TITLE
Guess template name based on declared method name when using @Template

### DIFF
--- a/Templating/TemplateGuesser.php
+++ b/Templating/TemplateGuesser.php
@@ -77,6 +77,14 @@ class TemplateGuesser
             $bundleName = null;
         }
 
+        foreach (get_class_methods($className) as $method) {
+            if ($method !== $matchAction[0] && strtolower($method) === strtolower($matchAction[0])) {
+                preg_match('/^(.+)Action$/', $method, $matchAction);
+
+                break;
+            }
+        }
+
         return new TemplateReference($bundleName, $matchController[1], $matchAction[1], $request->getRequestFormat(), $engine);
     }
 


### PR DESCRIPTION
Stumbled upon this while developing on OS X which has a case-insensitive filesystem. For various non-obvious reasons I ended up calling a controller action using `mycontrollerAction` instead of `myControllerAction`.

Since I was using the `@Template` annotation without any parameters, the template name was guessed, but the guess was based on what I called the controller as, not the actual controller method name, resulting in `mycontroller.html.twig` instead of `myController.html.twig`.

This of course worked fine locally, but failed when pushed to our staging server (which has a case-sensitive file system).