### PR TITLE
Made the bundle compatible with Symfony 2.3 LTS again

### DIFF
--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -74,8 +75,11 @@ class SensioFrameworkExtraExtension extends Extension
         if ($config['security']['annotations']) {
             $annotationsToLoad[] = 'security.xml';
 
-            $container->setAlias('sensio_framework_extra.security.expression_language', $config['security']['expression_language']);
-            $container->getAlias('sensio_framework_extra.security.expression_language')->setPublic(false);
+            if (class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage') && class_exists('Symfony\Component\Security\Core\Authorization\ExpressionLanguage')) {
+                $container->setAlias('sensio_framework_extra.security.expression_language', new Alias($config['security']['expression_language'], false));
+            } else {
+                $container->removeDefinition('sensio_framework_extra.security.expression_language.default');
+            }
 
             $this->addClassesToCompile(array(
                 'Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\SecurityListener',

--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -51,6 +50,10 @@ class SecurityListener implements EventSubscriberInterface
 
         if (null === $this->securityContext || null === $this->trustResolver) {
             throw new \LogicException('To use the @Security tag, you need to install the Symfony Security bundle.');
+        }
+
+        if (null === $this->language) {
+            throw new \LogicException('To use the @Security tag, you need to use the Security component 2.4 or newer and to install the ExpressionLanguage component.');
         }
 
         if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.5",
+        "symfony/framework-bundle": "~2.3",
         "doctrine/common": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
Forbidding to use SensioFrameworkExtraBundle 3.0 on 2.3 and 2.4 is a bad idea, given that people want to use the new features.

Here is the current state:
- using `@Method` on a class will only work in Symfony 2.5+. It will be ignored for older versions of Symfony (just like when using 3.0.0 of this bundle)
- the `security:check` command will only work in Symfony 2.4+ as it is registered as service. It will not be registered for 2.3 users (we could find a way to register it in 2.3, but the blog announces it as a new 2.6 feature anyway)
- using `@Security` requires Symfony 2.4+
- using the `lastModified` or `etag` properties of `@Cache` requires installing the ExpressionLanguage component (you can install it in a 2.3 project as it is totally standalone)
