### PR TITLE
[Template] annotation with namespace name resolving

### DIFF
--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -50,6 +50,20 @@ class Template extends ConfigurationAnnotation
     protected $streamable = false;
 
     /**
+     * Should the template name resolved as namespace?
+     *
+     * @var bool
+     */
+    protected $namespaced = null;
+
+    /**
+     * Namespace for resolving template
+     *
+     * @var string
+     */
+    protected $namespace = false;
+
+    /**
      * Returns the array of templates variables.
      *
      * @return array
@@ -73,6 +87,38 @@ class Template extends ConfigurationAnnotation
     public function isStreamable()
     {
         return (bool) $this->streamable;
+    }
+
+    /**
+     * @param bool    $namespaced
+     */
+    public function setIsNamespaced($namespaced)
+    {
+        $this->namespaced = $namespaced;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNamespaced()
+    {
+        return (bool) $this->namespaced;
+    }
+
+    /**
+     * @param string    $namespace
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
     }
 
     /**

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -61,7 +61,15 @@ class TemplateListener implements EventSubscriberInterface
 
         if (!$configuration->getTemplate()) {
             $guesser = $this->container->get('sensio_framework_extra.view.guesser');
-            $configuration->setTemplate($guesser->guessTemplateName($controller, $request, $configuration->getEngine()));
+            $template = null;
+
+            if ($configuration->isNamespaced() || $configuration->getNamespace()) {
+                $template = $guesser->guessNamespaceTemplateName($controller, $request, $configuration->getEngine(), $configuration->getNamespace());
+            } else {
+                $template = $guesser->guessTemplateName($controller, $request, $configuration->getEngine());
+            }
+
+            $configuration->setTemplate($template);
         }
 
         $request->attributes->set('_template', $configuration->getTemplate());

--- a/Templating/NamespaceTemplateReference.php
+++ b/Templating/NamespaceTemplateReference.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Templating;
+
+use Symfony\Component\Templating\TemplateReference as BaseTemplateReference;
+
+/**
+ * Internal representation of a template called with namespace.
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+class NamespaceTemplateReference extends BaseTemplateReference
+{
+    public function __construct($namespace = null, $controller = null, $name = null, $format = null, $engine = null)
+    {
+        $this->parameters = array(
+            'namespace'  => $namespace,
+            'controller' => $controller,
+            'name'       => $name,
+            'format'     => $format,
+            'engine'     => $engine,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        $controller = str_replace('\\', '/', $this->get('controller'));
+
+        return (empty($controller) ? '' : $controller.'/').$this->get('name').'.'.$this->get('format').'.'.$this->get('engine');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogicalName()
+    {
+        return sprintf('@%s/%s', $this->parameters['namespace'], $this->getPath());
+    }
+}

--- a/Tests/Templating/TemplateGuesserTest.php
+++ b/Tests/Templating/TemplateGuesserTest.php
@@ -52,6 +52,36 @@ class TemplateGuesserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FooBundle:Foo:index.html.twig', (string) $templateReference);
     }
 
+    public function testGuessTemplateNamespaceName()
+    {
+        $this->kernel
+            ->expects($this->never())
+            ->method('getBundle');
+
+        $templateGuesser = new TemplateGuesser($this->kernel);
+        $templateReference = $templateGuesser->guessNamespaceTemplateName(array(
+            new Fixture\FooBundle\Controller\FooController(),
+            'indexAction',
+        ), new Request());
+
+        $this->assertEquals('@FooBundle/Foo/index.html.twig', (string) $templateReference);
+    }
+
+    public function testGuessTemplateNamespaceNameWithNamespace()
+    {
+        $this->kernel
+            ->expects($this->never())
+            ->method('getBundle');
+
+        $templateGuesser = new TemplateGuesser($this->kernel);
+        $templateReference = $templateGuesser->guessNamespaceTemplateName(array(
+            new Fixture\FooBundle\Controller\FooController(),
+            'indexAction',
+        ), new Request(), 'twig', 'fooNamespace');
+
+        $this->assertEquals('@fooNamespace/Foo/index.html.twig', (string) $templateReference);
+    }
+
     public function testGuessTemplateNameWithParentBundle()
     {
         $this->kernel


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Patch that resolve Template annotation as a template with namespace.

Usage: 
    /**
     * @Template(isNamespaced=true)
     * Will be loaded template with name "@FooBundle/Controller/action.html.twig"
     */

    /**
     * @Template(namespace="foo")
     * Will be loaded template with name "@foo/Controller/action.html.twig"
     */

Props:
1. a little bit faster
2. Easy usage of namespaces for templates by annotation
