### PR TITLE
Test that a token is set to use the @Security tag

### DIFF
--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -52,6 +52,10 @@ class SecurityListener implements EventSubscriberInterface
             throw new \LogicException('To use the @Security tag, you need to install the Symfony Security bundle.');
         }
 
+        if (null === $this->securityContext->getToken()) {
+            throw new \LogicException('To use the @Security tag, your controller needs to be behind a firewall.');
+        }
+
         if (null === $this->language) {
             throw new \LogicException('To use the @Security tag, you need to use the Security component 2.4 or newer and to install the ExpressionLanguage component.');
         }


### PR DESCRIPTION
Fix a bug when the Security annotation is used on a controller which is not behind a firewall