### PR TITLE
Adding an experimental PreExecuteListener

### DIFF
--- a/Controller/PreExecuteInterface.php
+++ b/Controller/PreExecuteInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface PreExecuteInterface
+{
+    public function preExecute(Request $request, $methodName);
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -66,6 +66,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('expression_language')->defaultValue('sensio_framework_extra.security.expression_language.default')->end()
                     ->end()
                 ->end()
+                ->arrayNode('controller_filters')
+                    ->canBeEnabled()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -102,6 +102,15 @@ class SensioFrameworkExtraExtension extends Extension
                 $container->getDefinition('sensio_framework_extra.converter.listener')->replaceArgument(1, $config['request']['auto_convert']);
             }
         }
+
+        if ($config['controller_filters']['enabled']) {
+            $loader->load('controller_filters.xml');
+
+            $this->addClassesToCompile(array(
+                'Sensio\\Bundle\\FrameworkExtraBundle\\Controller\\PreExecuteInterface',
+                'Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\PreExecuteListener',
+            ));
+        }
     }
 
     /**

--- a/EventListener/PreExecuteListener.php
+++ b/EventListener/PreExecuteListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
+
+use Sensio\Bundle\FrameworkExtraBundle\Controller\PreExecuteInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Calls PreExecuteInterface controllers
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class PreExecuteListener implements EventSubscriberInterface
+{
+    /**
+     * Guesses the template name to render and its variables and adds them to
+     * the request object.
+     *
+     * @param FilterControllerEvent $event A FilterControllerEvent instance
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        if (!is_array($controller = $event->getController())) {
+            return;
+        }
+
+        $controllerObject = $controller[0];
+        if (!$controllerObject instanceof PreExecuteInterface) {
+            return;
+        }
+
+        $controllerObject->preExecute($event->getRequest(), $controller[1]);
+    }
+
+    public static function getSubscribedEvents()
+      {
+          return array(
+              KernelEvents::CONTROLLER => 'onKernelController',
+          );
+      }
+}

--- a/EventListener/PreExecuteListener.php
+++ b/EventListener/PreExecuteListener.php
@@ -46,7 +46,8 @@ class PreExecuteListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
       {
           return array(
-              KernelEvents::CONTROLLER => 'onKernelController',
+              // slightly positive so that it runs before things like @Security
+              KernelEvents::CONTROLLER => array('onKernelController', 10),
           );
       }
 }

--- a/Resources/config/controller_filters.xml
+++ b/Resources/config/controller_filters.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sensio_framework_extra.pre_execute.listener" class="Sensio\Bundle\FrameworkExtraBundle\EventListener\PreExecuteListener">
+            <tag name="kernel.event_subscriber" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Hi guys!

This is an idea that I wanted feedback on. With this, if you controller implements a new interface, then a `preExecute()` method will be called before executing the action.

The problems I'm hoping to make smoother:

1) Applying security to most or an entire controller
2) More powerful param converters, because they can be done in PHP - the ParamConverter configuration is ugly, and not everyone likes annotations anyways.
3) Because of (2), the possibility that `@Security` can be used more easily, when you're checking against objects:

```php
// use statements ...

class CategoryController extends Controller implements PreExecuteInterface
{
    public function preExecute(Request $request, $methodName)
    {
        $this->denyAccessUnlessGranted('ROLE_ADMIN');

        if ($id = $request->attributes->get('id')) {
            $categoryRepository = $this->getDoctrine()
                ->getRepository('AppBundle:Category');

            $category = $categoryRepository->find($id);
            if (!$category) {
                throw $this->createNotFoundException();
            }

            $request->attributes->set('category', $category);
        }
    }

    /**
     * @Route("/category/{id}", name="category_show")
     * @Security("is_granted('CATEGORY_SHOW', category)")
     */
    public function showCategoryAction($category)
    {
        return $this->render('fortune/showCategory.html.twig',[
            'category' => $category
        ]);
    }
}
```

What do you think of this? Would you use it or not? Any ideas/improvements?

Thanks!