### PR TITLE
[ParamConverter] Validate the configuration options

### DIFF
--- a/Request/ParamConverter/ResolvedOptionsInterface.php
+++ b/Request/ParamConverter/ResolvedOptionsInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * ResolvedOptionsInterface.
+ *
+ * @author Sofiane HADDAG <sofiane.haddag@yahoo.fr>
+ */
+interface ResolvedOptionsInterface
+{
+    /**
+     * Configure the Options Resolver
+     *
+     * @param OptionsResolver $resolver The OptionsResolver instance
+     */
+    public function configureResolver(OptionsResolver $resolver);
+}


### PR DESCRIPTION
(_Tests: WIP_)
Add ability to validate the configuration options using the OptionsResolver component.

``` PHP
use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ResolvedOptionsInterface;

class MyParamConverter implements ParamConverterInterface, ResolvedOptionsInterface
{
    /**
     * {@inheritdoc}
     */
    public function apply(Request $request, ParamConverter $configuration)
    {
        ...
    }

    /**
     * {@inheritdoc}
     */
    public function supports(ParamConverter $configuration)
    {
        ...
    }

    /**
     * {@inheritdoc}
     */
    public function configureResolver(OptionsResolver $resolver)
     {
        $resolver->setDefaults(...);

        $resolver->setRequired(...);
    }
}
```
