### PR TITLE
Fix BC break issue #345 cache public

### DIFF
--- a/Configuration/Cache.php
+++ b/Configuration/Cache.php
@@ -139,7 +139,17 @@ class Cache extends ConfigurationAnnotation
      */
     public function isPublic()
     {
-        return (bool) $this->public;
+        return $this->public === true;
+    }
+
+    /**
+     * Returns whether or not a response is private.
+     *
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return $this->public === false;
     }
 
     /**

--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -125,7 +125,9 @@ class HttpCacheListener implements EventSubscriberInterface
 
         if ($configuration->isPublic()) {
             $response->setPublic();
-        } else {
+        }
+
+        if ($configuration->isPrivate()) {
             $response->setPrivate();
         }
 

--- a/Tests/EventListener/HttpCacheListenerTest.php
+++ b/Tests/EventListener/HttpCacheListenerTest.php
@@ -77,6 +77,16 @@ class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
     }
 
+    public function testResponseIsNeitherPrivateNorPublicIfConfigurationIsPublicNotSet()
+    {
+        $request = $this->createRequest(new Cache());
+
+        $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
+
+        $this->assertFalse($this->response->headers->hasCacheControlDirective('public'));
+        $this->assertFalse($this->response->headers->hasCacheControlDirective('private'));
+    }
+
     public function testConfigurationAttributesAreSetOnResponse()
     {
         $this->assertInternalType('null', $this->response->getMaxAge());

--- a/Tests/EventListener/HttpCacheListenerTest.php
+++ b/Tests/EventListener/HttpCacheListenerTest.php
@@ -79,7 +79,8 @@ class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testResponseIsNeitherPrivateNorPublicIfConfigurationIsPublicNotSet()
     {
-        $request = $this->createRequest(new Cache());
+        $request = $this->createRequest(new Cache(array(
+        )));
 
         $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
 


### PR DESCRIPTION
Fixes issue #345

When cache is not set to public nor set to private the response should
not be marked as public nor private