### PR TITLE
[Bugfix] Vary header should not be overridden

### DIFF
--- a/Configuration/Cache.php
+++ b/Configuration/Cache.php
@@ -54,7 +54,7 @@ class Cache extends ConfigurationAnnotation
      *
      * @var array
      */
-    protected $vary = array();
+    protected $vary;
 
     /**
      * An expression to compute the Last-Modified HTTP header.

--- a/Tests/EventListener/HttpCacheListenerTest.php
+++ b/Tests/EventListener/HttpCacheListenerTest.php
@@ -77,6 +77,30 @@ class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
     }
 
+    public function testResponseVary()
+    {
+        $vary = array('foobar');
+        $request = $this->createRequest(new Cache(array('vary' => $vary)));
+
+        $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
+        $this->assertTrue($this->response->hasVary());
+        $result = $this->response->getVary();
+        $this->assertEquals($vary, $result);
+    }
+
+    public function testResponseVaryWhenVaryNotSet()
+    {
+        $request = $this->createRequest(new Cache(array()));
+        $vary = array('foobar');
+        $this->response->setVary($vary);
+
+        $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
+        $this->assertTrue($this->response->hasVary());
+        $result = $this->response->getVary();
+        $this->assertFalse(empty($result), 'Existing vary headers should not be removed');
+        $this->assertEquals($vary, $result, 'Vary header should not be changed');
+    }
+
     public function testConfigurationAttributesAreSetOnResponse()
     {
         $this->assertInternalType('null', $this->response->getMaxAge());


### PR DESCRIPTION
We should not overwrite the vary header of the response if we have not configured vary-header in our cache annotation. 

The issue is because we check if [$configuration->getVary() is null](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/EventListener/HttpCacheListener.php#L122) but it never will be since we [declared the variable to be an array()](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/Configuration/Cache.php#L57).