### PR TITLE
[ParamConverter] made 404 error message configurable

### DIFF
--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -57,6 +57,13 @@ class ParamConverter extends ConfigurationAnnotation
     protected $converter;
 
     /**
+     * To be used as 404 error message when object is not found
+     *
+     * @var string
+     */
+    protected $message;
+
+    /**
      * Returns the parameter name.
      *
      * @return string
@@ -164,6 +171,22 @@ class ParamConverter extends ConfigurationAnnotation
     public function setConverter($converter)
     {
         $this->converter = $converter;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
     }
 
     /**

--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -57,7 +57,7 @@ class ParamConverter extends ConfigurationAnnotation
     protected $converter;
 
     /**
-     * To be used as 404 error message when object is not found
+     * To be used as 404 error message when object is not found.
      *
      * @var string
      */
@@ -164,7 +164,7 @@ class ParamConverter extends ConfigurationAnnotation
     }
 
     /**
-     * Set explicit converter name
+     * Set explicit converter name.
      *
      * @param string $converter
      */
@@ -193,6 +193,7 @@ class ParamConverter extends ConfigurationAnnotation
      * Returns the annotation alias name.
      *
      * @return string
+     *
      * @see ConfigurationInterface
      */
     public function getAliasName()
@@ -201,9 +202,10 @@ class ParamConverter extends ConfigurationAnnotation
     }
 
     /**
-     * Multiple ParamConverters are allowed
+     * Multiple ParamConverters are allowed.
      *
      * @return bool
+     *
      * @see ConfigurationInterface
      */
     public function allowArray()

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -63,7 +63,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
 
         if (null === $object && false === $configuration->isOptional()) {
-            throw new NotFoundHttpException(sprintf('%s object not found.', $class));
+            throw new NotFoundHttpException($configuration->getMessage() ? $configuration->getMessage() : sprintf('%s object not found.', $class));
         }
 
         $request->attributes->set($name, $object);

--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -210,6 +210,17 @@ the ``map_method_signature`` option to true. The default is false::
    When ``map_method_signature`` is ``true``, the ``firstName`` and
    ``lastName`` parameters do not have to be Doctrine fields.
 
+
+If prefer to use customized message in 404 error, add ``message`` configuration::
+
+    /**
+     * @ParamConverter("post", message="Oops! Not found!")
+     */
+    public function showAction(Post $post)
+    {
+        // 404 error message will be "Oops! Not found!" if $post is not found.
+    }
+
 DateTime Converter
 ~~~~~~~~~~~~~~~~~~
 

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -473,7 +473,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
 
         $ret = $this->converter->supports($config);
 
-        $this->assertTrue($ret, "Should be supported");
+        $this->assertTrue($ret, 'Should be supported');
     }
 
     public function testSupportsWithConfiguredEntityManager()
@@ -501,6 +501,6 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
 
         $ret = $this->converter->supports($config);
 
-        $this->assertTrue($ret, "Should be supported");
+        $this->assertTrue($ret, 'Should be supported');
     }
 }


### PR DESCRIPTION
Hi.
This PR enables customizing 404 error messages in ParamConverter by adding ``message`` configuration.
Usage is shown in doc diff: https://github.com/sensiolabs/SensioFrameworkExtraBundle/compare/sensiolabs:master...77web:paramconverter-configurable-message?expand=1#diff-0b540e20d1b1be77568646ad3de2d31e 

I hope you like it :smile:
Thank you.