### PR TITLE
Rename HttpMessageInterface to MessageInterface (PSR-7)

### DIFF
--- a/Request/ParamConverter/PsrServerRequestParamConverter.php
+++ b/Request/ParamConverter/PsrServerRequestParamConverter.php
@@ -28,7 +28,7 @@ class PsrServerRequestParamConverter implements ParamConverterInterface
     private static $supportedTypes = array(
         'Psr\Http\Message\ServerRequestInterface' => true,
         'Psr\Http\Message\RequestInterface' => true,
-        'Psr\Http\Message\HttpMessageInterface' => true,
+        'Psr\Http\Message\MessageInterface' => true,
     );
     /**
      * @var HttpMessageFactoryInterface

--- a/Tests/Request/ParamConverter/PsrServerRequestParamConverterTest.php
+++ b/Tests/Request/ParamConverter/PsrServerRequestParamConverterTest.php
@@ -39,7 +39,7 @@ class PsrServerRequestParamConverterTest extends \PHPUnit_Framework_TestCase
         $config = $this->createConfiguration('Psr\Http\Message\RequestInterface');
         $this->assertTrue($this->converter->supports($config));
 
-        $config = $this->createConfiguration('Psr\Http\Message\HttpMessageInterface');
+        $config = $this->createConfiguration('Psr\Http\Message\MessageInterface');
         $this->assertTrue($this->converter->supports($config));
 
         $config = $this->createConfiguration(__CLASS__);


### PR DESCRIPTION
HttpMessageInterface doesn't exist, see https://github.com/php-fig/http-message/blob/master/src/MessageInterface.php