### PR TITLE
Fix a BC notice when route path is empty in sf 2.7

### DIFF
--- a/Configuration/Route.php
+++ b/Configuration/Route.php
@@ -23,6 +23,10 @@ class Route extends BaseRoute
 
     public function setService($service)
     {
+        // avoid a BC notice in case of @Route(service="") with sf ^2.7
+        if (null === $this->getPath()) {
+            $this->setPath('');
+        }
         $this->service = $service;
     }
 
@@ -32,9 +36,10 @@ class Route extends BaseRoute
     }
 
     /**
-     * Multiple route annotations are allowed
+     * Multiple route annotations are allowed.
      *
      * @return bool
+     *
      * @see ConfigurationInterface
      */
     public function allowArray()

--- a/Tests/Configuration/RouteTest.php
+++ b/Tests/Configuration/RouteTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Configuration;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+/**
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ */
+class RouteTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetServiceWithoutPath()
+    {
+        $route = new Route(array());
+        $this->assertNull($route->getPath());
+        $this->assertNull($route->getService());
+
+        $route->setService('app.test');
+
+        $this->assertSame('', $route->getPath());
+        $this->assertSame('app.test', $route->getService());
+    }
+
+    public function testSetServiceWithPath()
+    {
+        $route = new Route(array());
+        $this->assertNull($route->getPath());
+        $this->assertNull($route->getService());
+
+        $route->setPath('/test/');
+        $route->setService('app.test');
+
+        $this->assertSame('/test/', $route->getPath());
+        $this->assertSame('app.test', $route->getService());
+    }
+
+    public function testSettersViaConstruct()
+    {
+        $route = new Route(array('service' => 'app.test'));
+        $this->assertSame('', $route->getPath());
+        $this->assertSame('app.test', $route->getService());
+
+        $route = new Route(array('service' => 'app.test', 'path' => '/test/'));
+        $this->assertSame('/test/', $route->getPath());
+        $this->assertSame('app.test', $route->getService());
+    }
+}


### PR DESCRIPTION
This PR fixes Issue #364 via the suggestion of @weaverryan. When `@Route(service="app.test")` is called, Symfony 2.7 will trigger a deprecation notice because it has no `path`, which in turns calls a deprecated getter after that. Now `setService` will call `setPath` if it wasn't set yet and fill it with an empty string to avoid the getter from being called.