### PR TITLE
[DX] Added safeguard to avoid silently overriding configuration that disallows array

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -93,8 +93,10 @@ class ControllerListener implements EventSubscriberInterface
             if ($configuration instanceof ConfigurationInterface) {
                 if ($configuration->allowArray()) {
                     $configurations['_'.$configuration->getAliasName()][] = $configuration;
-                } else {
+                } elseif (!isset($configurations['_'.$configuration->getAliasName()])) {
                     $configurations['_'.$configuration->getAliasName()] = $configuration;
+                } else {
+                    throw new \LogicException(sprintf('Configure "%s" multiple is not allowed', $configuration->getAliasName()));
                 }
             }
         }

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -55,10 +55,10 @@ class ControllerListener implements EventSubscriberInterface
         }
 
         $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
-        $object    = new \ReflectionClass($className);
-        $method    = $object->getMethod($controller[1]);
+        $object = new \ReflectionClass($className);
+        $method = $object->getMethod($controller[1]);
 
-        $classConfigurations  = $this->getConfigurations($this->reader->getClassAnnotations($object));
+        $classConfigurations = $this->getConfigurations($this->reader->getClassAnnotations($object));
         $methodConfigurations = $this->getConfigurations($this->reader->getMethodAnnotations($method));
 
         $configurations = array();

--- a/Tests/EventListener/ControllerListenerTest.php
+++ b/Tests/EventListener/ControllerListenerTest.php
@@ -16,6 +16,8 @@ use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClass;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClassAndMethod;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerMultipleCacheAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerMultipleCacheAtMethod;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerParamConverterAtClassAndMethod;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\HttpFoundation\Request;
@@ -86,6 +88,28 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($annotation);
         $this->assertInstanceOf('Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache', $annotation);
         $this->assertEquals(FooControllerCacheAtClassAndMethod::METHOD_SMAXAGE, $annotation->getSMaxAge());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Configure "cache" multiple is not allowed
+     */
+    public function testMultipleAnnotationsOnClassThrowsExceptionUnlessConfigurationAllowsArray()
+    {
+        $controller = new FooControllerMultipleCacheAtClass();
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Configure "cache" multiple is not allowed
+     */
+    public function testMultipleAnnotationsOnMethodThrowsExceptionUnlessConfigurationAllowsArray()
+    {
+        $controller = new FooControllerMultipleCacheAtMethod();
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
     }
 
     public function testMultipleParamConverterAnnotationsOnMethod()

--- a/Tests/EventListener/ControllerListenerTest.php
+++ b/Tests/EventListener/ControllerListenerTest.php
@@ -78,18 +78,6 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(FooControllerCacheAtClassAndMethod::CLASS_SMAXAGE, $this->getReadedCache()->getSMaxAge());
     }
 
-    public function testMultipleAnnotationsOnMethod()
-    {
-        $controller = new FooControllerCacheAtClassAndMethod();
-        $this->event = $this->getFilterControllerEvent(array($controller, 'bar3Action'), $this->request);
-        $this->listener->onKernelController($this->event);
-
-        $annotation = $this->getReadedCache();
-        $this->assertNotNull($annotation);
-        $this->assertInstanceOf('Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache', $annotation);
-        $this->assertEquals(FooControllerCacheAtClassAndMethod::METHOD_SMAXAGE, $annotation->getSMaxAge());
-    }
-
     /**
      * @expectedException \LogicException
      * @expectedExceptionMessage Configure "cache" multiple is not allowed

--- a/Tests/EventListener/Fixture/FooControllerCacheAtClassAndMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerCacheAtClassAndMethod.php
@@ -22,12 +22,4 @@ class FooControllerCacheAtClassAndMethod
     public function bar2Action()
     {
     }
-
-    /**
-     * @Cache(smaxage="15")
-     * @Cache(smaxage="25")
-     */
-    public function bar3Action()
-    {
-    }
 }

--- a/Tests/EventListener/Fixture/FooControllerMultipleCacheAtClass.php
+++ b/Tests/EventListener/Fixture/FooControllerMultipleCacheAtClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+/**
+ * @Cache()
+ * @Cache()
+ */
+class FooControllerMultipleCacheAtClass
+{
+    public function barAction()
+    {
+
+    }
+}

--- a/Tests/EventListener/Fixture/FooControllerMultipleCacheAtMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerMultipleCacheAtMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+class FooControllerMultipleCacheAtMethod
+{
+    /**
+     * @Cache()
+     * @Cache()
+     */
+    public function barAction()
+    {
+
+    }
+}


### PR DESCRIPTION
Hi,

When annotating multiple configuration that disallow array (such as `@Security`) to one action, previous ones will be ignored silently. It looked like not working to me when I experienced first time.

I think it will be better to have an ability to notice that it is an incorrect configurations.
thanks