### PR TITLE
TemplateListener: Don't pull the templating service from the container if it's not used

### DIFF
--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -91,7 +91,6 @@ class TemplateListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $parameters = $event->getControllerResult();
-        $templating = $this->container->get('templating');
 
         if (null === $parameters) {
             if (!$vars = $request->attributes->get('_template_vars')) {
@@ -113,6 +112,8 @@ class TemplateListener implements EventSubscriberInterface
         if (!$template = $request->attributes->get('_template')) {
             return $parameters;
         }
+
+        $templating = $this->container->get('templating');
 
         if (!$request->attributes->get('_template_streamable')) {
             $event->setResponse($templating->renderResponse($template, $parameters));


### PR DESCRIPTION
In our project, we've built an API with Symfony. Here we rely on view listeners to serialize the data that our API returns. Looking into the profiler, I noticed that on each request some time is spent on the TemplateListener although the controller returns an object the listener cannot handle.

Looking into the code, I noticed that the listener is always pulling the `templating` service from the container, even if it does not process the controller result. By doing so, the templating service is bootstrapped, although we might not need templating to answer the request.

My patch postpones the container call to a point where the listener has already decided that it can process the controller result.