### PR TITLE
Add an option to throw NotFoundHttpException

### DIFF
--- a/Configuration/Security.php
+++ b/Configuration/Security.php
@@ -19,7 +19,29 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  */
 class Security extends ConfigurationAnnotation
 {
+    /**
+     * The expression evaluated to allow or deny access.
+     *
+     * @var string
+     */
     protected $expression;
+
+    /**
+     * If set, will throw Symfony\Component\HttpKernel\Exception\HttpException
+     * with the given $statusCode.
+     * If null, Symfony\Component\Security\Core\Exception\AccessDeniedException.
+     * will be used.
+     *
+     * @var int
+     */
+    protected $statusCode;
+
+    /**
+     * The message of the exception.
+     *
+     * @var string
+     */
+    protected $message;
 
     public function getExpression()
     {
@@ -29,6 +51,26 @@ class Security extends ConfigurationAnnotation
     public function setExpression($expression)
     {
         $this->expression = $expression;
+    }
+
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    public function setStatusCode($statusCode)
+    {
+        $this->statusCode = $statusCode;
+    }
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    public function setMessage($message)
+    {
+        $this->message = $message;
     }
 
     public function setValue($expression)

--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -13,6 +13,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
 use Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -65,7 +66,12 @@ class SecurityListener implements EventSubscriberInterface
         }
 
         if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {
-            throw new AccessDeniedException(sprintf('Expression "%s" denied access.', $configuration->getExpression()));
+            if ($statusCode = $configuration->getStatusCode()) {
+                throw new HttpException($statusCode, $configuration->getMessage());
+            }
+
+            $message = $configuration->getMessage() ?: sprintf('Expression "%s" denied access.', $configuration->getExpression());
+            throw new AccessDeniedException($message);
         }
     }
 

--- a/Resources/doc/annotations/security.rst
+++ b/Resources/doc/annotations/security.rst
@@ -54,6 +54,26 @@ Here is another example, making use of multiple functions in the expression::
     {
     }
 
+You can throw an exception ``Symfony\Component\HttpKernel\Exception\HttpException``
+instead of ``Symfony\Component\Security\Core\Exception\AccessDeniedException``
+using the ``statusCode`` option::
+
+    /**
+     * @Security("is_granted('POST_SHOW', post)", statusCode=404)
+     */
+    public function showAction(Post $post)
+    {
+    }
+
+Option ``message`` will allow you to specify the message of the exception::
+
+    /**
+     * @Security("is_granted('POST_SHOW', post)", statusCode=404, message="Resource not found.")
+     */
+    public function showAction(Post $post)
+    {
+    }
+
 .. note::
 
     Defining a ``Security`` annotation has the same effect as defining an


### PR DESCRIPTION
…instead of AccessDeniedException.

For security reason, it is sometime better to return status code 404 when a user doesn't have access to a resource to prevent leaking private informations.

This PR adds a new option on the `@Security` annotation

```
    /**
     * @Security("is_granted('POST_SHOW', post)", notFound=true)
     */
    public function showAction(Post $post)
    {
    }
```
