### PR TITLE
remove build job for nightly PHP build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,13 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - nightly
+  - 7.0
   - hhvm
 
 matrix:
   include:
     - php: 5.3
       env: deps=low
-  allow_failures:
-      - php: nightly
   fast_finish: true
 
 env:


### PR DESCRIPTION
The `nightly` PHP version on Travis CI is no longer PHP 7.0 but the nightly build of PHP 7.1.

Furthermore, builds on PHP 7 should no longer be allowed to fail as PHP 7 is almost stable and we should rather report bugs to PHP itself instead of silently ignore such errors.