### PR TITLE
Custom 'not found message' for 'ParamConvertor' when object is not found

### DIFF
--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -125,6 +125,28 @@ class ParamConverter extends ConfigurationAnnotation
     }
 
     /**
+     * Get a option by name.
+     *
+     * @param string $name Name of option
+     * @return null
+     */
+    public function getOption($name)
+    {
+        return $this->hasOption($name) ? $this->options[$name] : null;
+    }
+
+    /**
+     * Check whether a options is exists.
+     *
+     * @param string $name Name of option
+     * @return bool
+     */
+    public function hasOption($name)
+    {
+        return isset($this->options[$name]) ?: false;
+    }
+
+    /**
      * Sets whether or not the parameter is optional.
      *
      * @param bool $optional Wether the parameter is optional

--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -128,7 +128,6 @@ class ParamConverter extends ConfigurationAnnotation
      * Get a option by name.
      *
      * @param string $name Name of option
-     * @return null
      */
     public function getOption($name)
     {
@@ -139,6 +138,7 @@ class ParamConverter extends ConfigurationAnnotation
      * Check whether a options is exists.
      *
      * @param string $name Name of option
+     *
      * @return bool
      */
     public function hasOption($name)

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -63,7 +63,9 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
 
         if (null === $object && false === $configuration->isOptional()) {
-            throw new NotFoundHttpException(sprintf('%s object not found.', $class));
+            $notFoundMessage = $configuration->hasOption('notFoundMessage') ?
+                $configuration->getOption('notFoundMessage') : sprintf('%s object not found.', $class);
+            throw new NotFoundHttpException($notFoundMessage);
         }
 
         $request->attributes->set($name, $object);


### PR DESCRIPTION
Custom 'not found message' for 'ParamConvertor' when object is not found