### PR TITLE
[Routing] fix to allow verbs http annotation @Method("GET|POST")

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -50,7 +50,7 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         // requirements (@Method)
         foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
             if ($configuration instanceof Method) {
-                $route->setMethods($configuration->getMethods());
+                $route->setMethods(explode('|', implode('|', $configuration->getMethods())));
             } elseif ($configuration instanceof FrameworkExtraBundleRoute && $configuration->getService()) {
                 throw new \LogicException('The service option can only be specified at class level.');
             }

--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -50,7 +50,8 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         // requirements (@Method)
         foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
             if ($configuration instanceof Method) {
-                $route->setMethods(explode('|', implode('|', $configuration->getMethods())));
+                $methods = implode('|', $configuration->getMethods());
+                $route->setMethods(explode('|', $methods));
             } elseif ($configuration instanceof FrameworkExtraBundleRoute && $configuration->getService()) {
                 throw new \LogicException('The service option can only be specified at class level.');
             }

--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -50,7 +50,7 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         // requirements (@Method)
         foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
             if ($configuration instanceof Method) {
-                $route->setMethods(implode('|', $configuration->getMethods()));
+                $route->setMethods($configuration->getMethods());
             } elseif ($configuration instanceof FrameworkExtraBundleRoute && $configuration->getService()) {
                 throw new \LogicException('The service option can only be specified at class level.');
             }

--- a/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -147,7 +147,7 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
         $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\BuzzController');
 
         $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
-        $this->assertCount(3, $rc);
+        $this->assertCount(4, $rc);
 
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('index'));
         // depending on the Symfony version, it can return GET or an empty array (on 2.3)
@@ -157,6 +157,7 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('new'));
         $this->assertEquals(array('GET', 'POST'), $rc->get('new')->getMethods());
+        $this->assertEquals(array('POST', 'DELETE'), $rc->get('bar')->getMethods());
         $this->assertEquals(array('PUT', 'POST'), $rc->get('foo')->getMethods());
     }
 }

--- a/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -147,7 +147,7 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
         $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\BuzzController');
 
         $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
-        $this->assertCount(2, $rc);
+        $this->assertCount(3, $rc);
 
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('index'));
         // depending on the Symfony version, it can return GET or an empty array (on 2.3)
@@ -157,5 +157,6 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('new'));
         $this->assertEquals(array('GET', 'POST'), $rc->get('new')->getMethods());
+        $this->assertEquals(array('PUT', 'POST'), $rc->get('foo')->getMethods());
     }
 }

--- a/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -138,4 +138,24 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('new'));
         $this->assertEquals(array('POST'), $rc->get('new')->getMethods());
     }
+
+    public function testLoadMethod()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\BuzzController');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
+        $this->assertCount(2, $rc);
+
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('index'));
+        // depending on the Symfony version, it can return GET or an empty array (on 2.3)
+        // which has the same behavior anyway
+        $methods = $rc->get('index')->getMethods();
+        $this->assertTrue(empty($methods) || array('GET') == $methods);
+
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('new'));
+        $this->assertEquals(array('GET', 'POST'), $rc->get('new')->getMethods());
+    }
 }

--- a/Tests/Routing/Fixtures/BuzzController.php
+++ b/Tests/Routing/Fixtures/BuzzController.php
@@ -24,4 +24,13 @@ class BuzzController
     public function newAction()
     {
     }
+
+    /**
+     * @Route("/foo", name="foo")
+     * @Method("PUT|POST")
+     */
+    public function fooAction()
+    {
+    }
+
 }

--- a/Tests/Routing/Fixtures/BuzzController.php
+++ b/Tests/Routing/Fixtures/BuzzController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+
+/**
+ * @Route("/base")
+ */
+class BuzzController
+{
+    /**
+     * @Route("/", name="index")
+     */
+    public function indexAction()
+    {
+    }
+
+    /**
+     * @Route("/new", name="new")
+     * @Method({"GET", "POST"})
+     */
+    public function newAction()
+    {
+    }
+}

--- a/Tests/Routing/Fixtures/BuzzController.php
+++ b/Tests/Routing/Fixtures/BuzzController.php
@@ -26,11 +26,18 @@ class BuzzController
     }
 
     /**
+     * @Route("/foo", name="bar")
+     * @Method({"POST", "DELETE"})
+     */
+    public function barAction()
+    {
+    }
+
+    /**
      * @Route("/foo", name="foo")
      * @Method("PUT|POST")
      */
     public function fooAction()
     {
     }
-
 }


### PR DESCRIPTION
Inside $route->setMethods() is called implode()
I think this issue solve #312 