### PR TITLE
Fix ControllerListener annotations retrieval for invokable controllers

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -50,15 +50,16 @@ class ControllerListener implements EventSubscriberInterface
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        if (!is_array($controller = $event->getController())) {
+        if (!is_array($controller = $event->getController()) && !is_object($controller)) {
             return;
         }
 
-        $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
-        $object = new \ReflectionClass($className);
-        $method = $object->getMethod($controller[1]);
+        list($object, $methodName) = is_array($controller) ? $controller : array($controller, '__invoke');
+        $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($object) : get_class($object);
+        $class = new \ReflectionClass($className);
+        $method = $class->getMethod($methodName);
 
-        $classConfigurations = $this->getConfigurations($this->reader->getClassAnnotations($object));
+        $classConfigurations = $this->getConfigurations($this->reader->getClassAnnotations($class));
         $methodConfigurations = $this->getConfigurations($this->reader->getMethodAnnotations($method));
 
         $configurations = array();

--- a/Tests/EventListener/ControllerListenerTest.php
+++ b/Tests/EventListener/ControllerListenerTest.php
@@ -15,6 +15,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClass;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClassAndMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheOnInvokableController;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtMethod;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerMultipleCacheAtClass;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerMultipleCacheAtMethod;
@@ -50,6 +51,17 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($this->getReadedCache());
         $this->assertEquals(FooControllerCacheAtMethod::METHOD_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
+    public function testCacheAnnotationOnInvokableController()
+    {
+        $controller = new FooControllerCacheOnInvokableController();
+
+        $this->event = $this->getFilterControllerEvent($controller, $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheOnInvokableController::INVOKE_SMAXAGE, $this->getReadedCache()->getSMaxAge());
     }
 
     public function testCacheAnnotationAtClass()

--- a/Tests/EventListener/Fixture/FooControllerCacheOnInvokableController.php
+++ b/Tests/EventListener/Fixture/FooControllerCacheOnInvokableController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+class FooControllerCacheOnInvokableController
+{
+    const INVOKE_SMAXAGE = 15;
+
+    /**
+     * @Cache(smaxage="15")
+     */
+    public function __invoke()
+    {
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony/issues/16451

However, I think that for such controllers, having the annotation at the class level makes much sense.