### PR TITLE
Fixed documentation example of @Cache ETag field

### DIFF
--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -62,7 +62,7 @@ response is not modified (in this case, the controller is **not** called)::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
     /**
-     * @Cache(lastModified="post.getUpdatedAt()", ETag="'Post' ~ post.getId() ~ post.getUpdatedAt()")
+     * @Cache(lastModified="post.getUpdatedAt()", ETag="'Post' ~ post.getId() ~ post.getUpdatedAt().getTimestamp()")
      */
     public function indexAction(Post $post)
     {

--- a/Resources/doc/annotations/cache.rst
+++ b/Resources/doc/annotations/cache.rst
@@ -93,14 +93,14 @@ Attributes
 
 Here is a list of accepted attributes and their HTTP header equivalent:
 
-===================================================== ================================
-Annotation                                            Response Method
-===================================================== ================================
-``@Cache(expires="tomorrow")``                        ``$response->setExpires()``
-``@Cache(smaxage="15")``                              ``$response->setSharedMaxAge()``
-``@Cache(maxage="15")``                               ``$response->setMaxAge()``
-``@Cache(vary={"Cookie"})``                           ``$response->setVary()``
-``@Cache(public=true)``                               ``$response->setPublic()``
-``@Cache(lastModified="post.getUpdatedAt()")``        ``$response->setLastModified()``
-``@Cache(ETag="post.getId() ~ post.getUpdatedAt()")`` ``$response->setETag()``
-===================================================== ================================
+======================================================================= ================================
+Annotation                                                              Response Method
+======================================================================= ================================
+``@Cache(expires="tomorrow")``                                          ``$response->setExpires()``
+``@Cache(smaxage="15")``                                                ``$response->setSharedMaxAge()``
+``@Cache(maxage="15")``                                                 ``$response->setMaxAge()``
+``@Cache(vary={"Cookie"})``                                             ``$response->setVary()``
+``@Cache(public=true)``                                                 ``$response->setPublic()``
+``@Cache(lastModified="post.getUpdatedAt()")``                          ``$response->setLastModified()``
+``@Cache(ETag="post.getId() ~ post.getUpdatedAt().getTimestamp()")``    ``$response->setETag()``
+======================================================================= ================================


### PR DESCRIPTION
Hello!

Currently i'm working with Symfony 2.7 and tried to use @Cache example from documentation. Current example doesn't work. 

`ETag` field on annotation used with concat and Expression language expects string for concat operation, but example written for using with `\DateTime` object. (`setLastModifed` already expects `\DateTime` object)

With current example i'm getting `Catchable Fatal Error: Object of class DateTime could not be converted to string`. So i changed example with working version.