### PR TITLE
Fix deprecated use of SecurityContextInterface.

### DIFF
--- a/Tests/EventListener/SecurityListenerTest.php
+++ b/Tests/EventListener/SecurityListenerTest.php
@@ -26,6 +26,10 @@ class SecurityListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testLegacyAccessDenied()
     {
+        if (!interface_exists('Symfony\Component\Security\Core\SecurityContextInterface')) {
+            $this->markTestSkipped();
+        }
+
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');


### PR DESCRIPTION
A test was still using the Core\SecurityContextInterface from the Security component, making the test suit crash. It now pass.

Edit : Added a commit to make the test also pass for PHP 5.3.