### PR TITLE
Remove deprecated use of SecurityContextInterface.

### DIFF
--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -19,7 +19,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
@@ -30,19 +29,19 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
  */
 class SecurityListener implements EventSubscriberInterface
 {
-    private $tokenStorage;
-    private $authChecker;
     private $language;
     private $trustResolver;
     private $roleHierarchy;
+    private $tokenStorage;
+    private $authChecker;
 
-    public function __construct(SecurityContextInterface $securityContext = null, ExpressionLanguage $language = null, AuthenticationTrustResolverInterface $trustResolver = null, RoleHierarchyInterface $roleHierarchy = null, TokenStorageInterface $tokenStorage = null, AuthorizationCheckerInterface $authChecker = null)
+    public function __construct(ExpressionLanguage $language = null, AuthenticationTrustResolverInterface $trustResolver = null, RoleHierarchyInterface $roleHierarchy = null, TokenStorageInterface $tokenStorage = null, AuthorizationCheckerInterface $authChecker = null)
     {
-        $this->tokenStorage = $tokenStorage ?: $securityContext;
-        $this->authChecker = $authChecker ?: $securityContext;
         $this->language = $language;
         $this->trustResolver = $trustResolver;
         $this->roleHierarchy = $roleHierarchy;
+        $this->tokenStorage = $tokenStorage;
+        $this->authChecker = $authChecker;
     }
 
     public function onKernelController(FilterControllerEvent $event)

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -6,7 +6,6 @@
 
     <services>
         <service id="sensio_framework_extra.security.listener" class="Sensio\Bundle\FrameworkExtraBundle\EventListener\SecurityListener">
-            <argument type="service" id="security.context" on-invalid="null" />
             <argument type="service" id="sensio_framework_extra.security.expression_language" on-invalid="null" />
             <argument type="service" id="security.authentication.trust_resolver" on-invalid="null" />
             <argument type="service" id="security.role_hierarchy" on-invalid="null" />

--- a/Tests/EventListener/SecurityListenerTest.php
+++ b/Tests/EventListener/SecurityListenerTest.php
@@ -31,15 +31,17 @@ class SecurityListenerTest extends \PHPUnit_Framework_TestCase
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->once())->method('getRoles')->will($this->returnValue(array()));
 
-        $securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $securityContext->expects($this->once())->method('isGranted')->will($this->throwException(new AccessDeniedException()));
-        $securityContext->expects($this->exactly(2))->method('getToken')->will($this->returnValue($token));
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage->expects($this->exactly(2))->method('getToken')->will($this->returnValue($token));
+
+        $authChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authChecker->expects($this->once())->method('isGranted')->will($this->throwException(new AccessDeniedException()));
 
         $trustResolver = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface');
 
         $language = new ExpressionLanguage();
 
-        $listener = new SecurityListener($securityContext, $language, $trustResolver);
+        $listener = new SecurityListener($language, $trustResolver, null, $tokenStorage, $authChecker);
         $request = $this->createRequest(new Security(array('expression' => 'has_role("ROLE_ADMIN") or is_granted("FOO")')));
 
         $event = new FilterControllerEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), function () { return new Response(); }, $request, null);
@@ -69,7 +71,7 @@ class SecurityListenerTest extends \PHPUnit_Framework_TestCase
 
         $language = new ExpressionLanguage();
 
-        $listener = new SecurityListener(null, $language, $trustResolver, null, $tokenStorage, $authChecker);
+        $listener = new SecurityListener($language, $trustResolver, null, $tokenStorage, $authChecker);
         $request = $this->createRequest(new Security(array('expression' => 'has_role("ROLE_ADMIN") or is_granted("FOO")')));
 
         $event = new FilterControllerEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), function () { return new Response(); }, $request, null);

--- a/Tests/EventListener/SecurityListenerTest.php
+++ b/Tests/EventListener/SecurityListenerTest.php
@@ -26,7 +26,9 @@ class SecurityListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testLegacyAccessDenied()
     {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+        if (!interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $this->markTestSkipped();
+        }
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->once())->method('getRoles')->will($this->returnValue(array()));


### PR DESCRIPTION
This is similar to https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/388 but it goes further by removing all references to the old SecurityContextInterface. I'm not sure it's not breaking BC, so I keep the two PR open for now.