### PR TITLE
Reduce reflection calls from 3 to 2 in most cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /vendor
 coverage
+/Tests/Fixtures/cache
 phpunit.xml
-vendor
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/vendor
 coverage
 phpunit.xml
 vendor

--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -24,7 +24,7 @@ class Template extends ConfigurationAnnotation
     /**
      * The template reference.
      *
-     * @var TemplateReference
+     * @var TemplateReference|string
      */
     protected $template;
 
@@ -48,6 +48,13 @@ class Template extends ConfigurationAnnotation
      * @var bool
      */
     protected $streamable = false;
+
+    /**
+     * The controller (+action) this annotation is set to.
+     *
+     * @var array
+     */
+    private $owner;
 
     /**
      * Returns the array of templates variables.
@@ -157,5 +164,23 @@ class Template extends ConfigurationAnnotation
     public function allowArray()
     {
         return false;
+    }
+
+    /**
+     * @param array $owner
+     */
+    public function setOwner(array $owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * The controller (+action) this annotation is attached to
+     *
+     * @return array
+     */
+    public function getOwner()
+    {
+        return $this->owner;
     }
 }

--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -175,7 +175,7 @@ class Template extends ConfigurationAnnotation
     }
 
     /**
-     * The controller (+action) this annotation is attached to
+     * The controller (+action) this annotation is attached to.
      *
      * @return array
      */

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -50,9 +50,7 @@ class ControllerListener implements EventSubscriberInterface
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        if (!is_array($controller = $event->getController())) {
-            return;
-        }
+        $controller = $event->getController();
 
         $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
         $object = new \ReflectionClass($className);

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -50,7 +50,9 @@ class ControllerListener implements EventSubscriberInterface
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        $controller = $event->getController();
+        if (!is_array($controller = $event->getController())) {
+            return;
+        }
 
         $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
         $object = new \ReflectionClass($className);

--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 
 /**
  * HttpCacheListener handles HTTP cache headers.

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -73,11 +73,10 @@ class TemplateListener implements EventSubscriberInterface
      * rendered template content.
      *
      * @param GetResponseForControllerResultEvent $event
-     * @return void
      */
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
-        /** @var Template $template */
+        /* @var Template $template */
         $request = $event->getRequest();
         $template = $request->attributes->get('_template');
 
@@ -132,6 +131,7 @@ class TemplateListener implements EventSubscriberInterface
      * @param Template $template
      * @param object   $controller
      * @param string   $action
+     *
      * @return array
      */
     private function resolveDefaultParameters(Request $request, Template $template, $controller, $action)

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -12,6 +12,7 @@
 namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -20,7 +21,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 /**
- * The TemplateListener class handles the Template annotation.
+ * Handles the Template annotation for actions.
+ *
+ * Depends on pre-processing of the ControllerListener.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -49,81 +52,71 @@ class TemplateListener implements EventSubscriberInterface
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        if (!is_array($controller = $event->getController())) {
-            return;
-        }
-
         $request = $event->getRequest();
+        $template = $request->attributes->get('_template');
 
-        if (!$configuration = $request->attributes->get('_template')) {
+        // no @Template present
+        if (null === $template) {
             return;
         }
 
-        if (!$configuration->getTemplate()) {
-            $guesser = $this->container->get('sensio_framework_extra.view.guesser');
-            $configuration->setTemplate($guesser->guessTemplateName($controller, $request, $configuration->getEngine()));
+        // we need the @Template annotation object or we cannot continue
+        if (!$template instanceof Template) {
+            throw new \InvalidArgumentException('Request attribute "_template" is reserved for @Template annotations.');
         }
 
-        $request->attributes->set('_template', $configuration->getTemplate());
-        $request->attributes->set('_template_vars', $configuration->getVars());
-        $request->attributes->set('_template_streamable', $configuration->isStreamable());
-
-        // all controller method arguments
-        if (!$configuration->getVars()) {
-            $r = new \ReflectionObject($controller[0]);
-
-            $vars = array();
-            foreach ($r->getMethod($controller[1])->getParameters() as $param) {
-                $vars[] = $param->getName();
-            }
-
-            $request->attributes->set('_template_default_vars', $vars);
-        }
+        $template->setOwner($event->getController());
     }
 
     /**
      * Renders the template and initializes a new response object with the
      * rendered template content.
      *
-     * @param GetResponseForControllerResultEvent $event A GetResponseForControllerResultEvent instance
+     * @param GetResponseForControllerResultEvent $event
+     * @return void
      */
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
+        /** @var Template $template */
         $request = $event->getRequest();
+        $template = $request->attributes->get('_template');
+
+        if (null === $template) {
+            return;
+        }
+
         $parameters = $event->getControllerResult();
+        $owner = $template->getOwner();
+        list($controller, $action) = $owner;
 
+        // when no template has been given, try to resolve it based on the controller
+        if (null === $template->getTemplate()) {
+            if ($action === '__invoke') {
+                throw new \InvalidArgumentException(sprintf('Cannot guess a template name for "%s::%s", please provide a template name.', get_class($controller), $action));
+            }
+
+            $guesser = $this->container->get('sensio_framework_extra.view.guesser');
+            $template->setTemplate($guesser->guessTemplateName($owner, $request, $template->getEngine()));
+        }
+
+        // when the annotation declares no default vars and the action returns
+        // null, all action method arguments are used as default vars
         if (null === $parameters) {
-            if (!$vars = $request->attributes->get('_template_vars')) {
-                if (!$vars = $request->attributes->get('_template_default_vars')) {
-                    return;
-                }
-            }
-
-            $parameters = array();
-            foreach ($vars as $var) {
-                $parameters[$var] = $request->attributes->get($var);
-            }
+            $parameters = $this->resolveDefaultParameters($request, $template, $controller, $action);
         }
 
-        if (!is_array($parameters)) {
-            return $parameters;
-        }
-
-        if (!$template = $request->attributes->get('_template')) {
-            return $parameters;
-        }
-
+        // attempt to render the actual response
         $templating = $this->container->get('templating');
 
-        if (!$request->attributes->get('_template_streamable')) {
-            $event->setResponse($templating->renderResponse($template, $parameters));
-        } else {
+        if ($template->isStreamable()) {
             $callback = function () use ($templating, $template, $parameters) {
-                return $templating->stream($template, $parameters);
+                return $templating->stream($template->getTemplate(), $parameters);
             };
 
             $event->setResponse(new StreamedResponse($callback));
         }
+
+        $event->setResponse($templating->renderResponse($template->getTemplate(), $parameters));
     }
 
     public static function getSubscribedEvents()
@@ -132,5 +125,35 @@ class TemplateListener implements EventSubscriberInterface
             KernelEvents::CONTROLLER => array('onKernelController', -128),
             KernelEvents::VIEW => 'onKernelView',
         );
+    }
+
+    /**
+     * @param Request  $request
+     * @param Template $template
+     * @param object   $controller
+     * @param string   $action
+     * @return array
+     */
+    private function resolveDefaultParameters(Request $request, Template $template, $controller, $action)
+    {
+        $parameters = array();
+        $arguments = $template->getVars();
+
+        if (0 === count($arguments)) {
+            $r = new \ReflectionObject($controller);
+
+            $arguments = array();
+            foreach ($r->getMethod($action)->getParameters() as $param) {
+                $arguments[] = $param->getName();
+            }
+        }
+
+        // fetch the arguments of @Template.vars or everything if desired
+        // and assign them to the designated template
+        foreach ($arguments as $argument) {
+            $parameters[$argument] = $request->attributes->get($argument);
+        }
+
+        return $parameters;
     }
 }

--- a/Tests/Fixtures/FooBundle/Controller/InvokableClassLevelController.php
+++ b/Tests/Fixtures/FooBundle/Controller/InvokableClassLevelController.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+/**
+ * @Route(service="test.invokable_class_level.predefined")
+ * @Template("FooBundle:Invokable:predefined.html.twig")
+ */
+class InvokableClassLevelController
+{
+    /**
+     * @Route("/invokable/class-level/service/")
+     */
+    public function __invoke()
+    {
+        return array(
+            'foo' => 'bar'
+        );
+    }
+}

--- a/Tests/Fixtures/FooBundle/Controller/InvokableClassLevelController.php
+++ b/Tests/Fixtures/FooBundle/Controller/InvokableClassLevelController.php
@@ -26,7 +26,7 @@ class InvokableClassLevelController
     public function __invoke()
     {
         return array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         );
     }
 }

--- a/Tests/Fixtures/FooBundle/Controller/InvokableContainerController.php
+++ b/Tests/Fixtures/FooBundle/Controller/InvokableContainerController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class InvokableContainerController extends Controller
+{
+    /**
+     * @Route("/invokable/variable/container/{variable}/")
+     * @Template()
+     */
+    public function variableAction($variable)
+    {
+    }
+
+    /**
+     * @Route("/invokable/another-variable/container/{variable}/")
+     * @Template("FooBundle:InvokableContainer:variable.html.twig")
+     */
+    public function anotherVariableAction($variable)
+    {
+        return array(
+            'variable' => $variable,
+        );
+    }
+
+    /**
+     * @Route("/invokable/variable/container/{variable}/{another_variable}/")
+     * @Template("FooBundle:InvokableContainer:another_variable.html.twig")
+     */
+    public function doubleVariableAction($variable, $another_variable)
+    {
+        return array(
+            'variable' => $variable,
+            'another_variable' => $another_variable,
+        );
+    }
+
+    /**
+     * @Route("/invokable/predefined/container/")
+     * @Template("FooBundle:Invokable:predefined.html.twig")
+     */
+    public function __invoke()
+    {
+        return array(
+            'foo' => 'bar'
+        );
+    }
+}

--- a/Tests/Fixtures/FooBundle/Controller/InvokableContainerController.php
+++ b/Tests/Fixtures/FooBundle/Controller/InvokableContainerController.php
@@ -55,7 +55,7 @@ class InvokableContainerController extends Controller
     public function __invoke()
     {
         return array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         );
     }
 }

--- a/Tests/Fixtures/FooBundle/Controller/InvokableController.php
+++ b/Tests/Fixtures/FooBundle/Controller/InvokableController.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+/**
+ * @Route(service="test.invokable.predefined")
+ */
+class InvokableController
+{
+    /**
+     * @Route("/invokable/predefined/service/")
+     * @Template("FooBundle:Invokable:predefined.html.twig")
+     */
+    public function __invoke()
+    {
+        return array(
+            'foo' => 'bar'
+        );
+    }
+}

--- a/Tests/Fixtures/FooBundle/Controller/InvokableController.php
+++ b/Tests/Fixtures/FooBundle/Controller/InvokableController.php
@@ -26,7 +26,7 @@ class InvokableController
     public function __invoke()
     {
         return array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         );
     }
 }

--- a/Tests/Fixtures/FooBundle/Controller/MultipleActionsClassLevelTemplateController.php
+++ b/Tests/Fixtures/FooBundle/Controller/MultipleActionsClassLevelTemplateController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Template("FooBundle:Invokable:predefined.html.twig")
+ */
+class MultipleActionsClassLevelTemplateController extends Controller
+{
+    /**
+     * @Route("/multi/one-template/1/")
+     */
+    public function firstAction()
+    {
+        return array(
+            'foo' => 'bar'
+        );
+    }
+
+    /**
+     * @Route("/multi/one-template/2/")
+     * @Route("/multi/one-template/3/")
+     */
+    public function secondAction()
+    {
+        return array(
+            'foo' => 'bar'
+        );
+    }
+
+    /**
+     * @Route("/multi/one-template/4/")
+     * @Template("FooBundle::overwritten.html.twig")
+     */
+    public function overwriteAction()
+    {
+        return array(
+            'foo' => 'foo bar baz'
+        );
+    }
+}

--- a/Tests/Fixtures/FooBundle/Controller/MultipleActionsClassLevelTemplateController.php
+++ b/Tests/Fixtures/FooBundle/Controller/MultipleActionsClassLevelTemplateController.php
@@ -26,7 +26,7 @@ class MultipleActionsClassLevelTemplateController extends Controller
     public function firstAction()
     {
         return array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         );
     }
 
@@ -37,7 +37,7 @@ class MultipleActionsClassLevelTemplateController extends Controller
     public function secondAction()
     {
         return array(
-            'foo' => 'bar'
+            'foo' => 'bar',
         );
     }
 
@@ -48,7 +48,7 @@ class MultipleActionsClassLevelTemplateController extends Controller
     public function overwriteAction()
     {
         return array(
-            'foo' => 'foo bar baz'
+            'foo' => 'foo bar baz',
         );
     }
 }

--- a/Tests/Fixtures/FooBundle/Controller/SimpleController.php
+++ b/Tests/Fixtures/FooBundle/Controller/SimpleController.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route(service="test.simple.multiple")
+ */
+class SimpleController
+{
+    /**
+     * @Route("/simple/multiple/", defaults={"a": "a", "b": "b"})
+     * @Template()
+     */
+    public function someAction($a, $b, $c = 'c')
+    {
+    }
+
+    /**
+     * @Route("/simple/multiple/{a}/{b}/")
+     * @Template("FooBundle:Simple:some.html.twig")
+     */
+    public function someMoreAction($a, $b, $c = 'c')
+    {
+    }
+
+    /**
+     * @Route("/simple/multiple-with-vars/", defaults={"a": "a", "b": "b"})
+     * @Template(vars={"a", "b"})
+     */
+    public function anotherAction($a, $b, $c = 'c')
+    {
+    }
+
+    /**
+     * @Route("/no-listener/")
+     */
+    public function noListenerAction()
+    {
+        return new Response('<html><body>I did not get rendered via twig</body></html>');
+    }
+
+    /**
+     * @Route("/streamed/")
+     * @Template(isStreamable=true)
+     */
+    public function streamedAction()
+    {
+        return array(
+            'foo' => 'foo',
+            'bar' => 'bar',
+        );
+    }
+}

--- a/Tests/Fixtures/FooBundle/FooBundle.php
+++ b/Tests/Fixtures/FooBundle/FooBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FooBundle extends Bundle
+{
+}

--- a/Tests/Fixtures/FooBundle/Resources/views/Invokable/predefined.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/Invokable/predefined.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ foo }}</body></html>

--- a/Tests/Fixtures/FooBundle/Resources/views/InvokableContainer/another_variable.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/InvokableContainer/another_variable.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ variable }},{{ another_variable }}</body></html>

--- a/Tests/Fixtures/FooBundle/Resources/views/InvokableContainer/variable.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/InvokableContainer/variable.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ variable }}</body></html>

--- a/Tests/Fixtures/FooBundle/Resources/views/Simple/another.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/Simple/another.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ a }}, {{ b }}</body></html>

--- a/Tests/Fixtures/FooBundle/Resources/views/Simple/some.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/Simple/some.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ a }}, {{ b }}, {{ c }}</body></html>

--- a/Tests/Fixtures/FooBundle/Resources/views/Simple/streamed.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/Simple/streamed.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ foo }}, {{ bar }}</body></html>

--- a/Tests/Fixtures/FooBundle/Resources/views/overwritten.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/overwritten.html.twig
@@ -1,0 +1,1 @@
+<html><body>{{ foo }}</body></html>

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -22,7 +22,7 @@ class TestKernel extends Kernel
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Tests\Fixtures\FooBundle\FooBundle()
+            new Tests\Fixtures\FooBundle\FooBundle(),
         );
     }
 

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Used for functional tests.
+ */
+class TestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+            new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new Tests\Fixtures\FooBundle\FooBundle()
+        );
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config/config.yml');
+    }
+
+    public function getCacheDir()
+    {
+        return $this->rootDir.'/cache/'.$this->environment;
+    }
+}

--- a/Tests/Fixtures/config/config.yml
+++ b/Tests/Fixtures/config/config.yml
@@ -1,0 +1,17 @@
+framework:
+    test: true
+    secret: test
+    templating:
+        engine: [twig, php]
+    router:
+        resource: %kernel.root_dir%/config/routing.yml
+
+services:
+    test.invokable.predefined:
+        class: Tests\Fixtures\FooBundle\Controller\InvokableController
+
+    test.invokable_class_level.predefined:
+        class: Tests\Fixtures\FooBundle\Controller\InvokableClassLevelController
+
+    test.simple.multiple:
+        class: Tests\Fixtures\FooBundle\Controller\SimpleController

--- a/Tests/Fixtures/config/routing.yml
+++ b/Tests/Fixtures/config/routing.yml
@@ -1,0 +1,3 @@
+foo_bundle:
+    resource: "@FooBundle/Controller"
+    type: annotation

--- a/Tests/Functional/TemplateAnnotationTest.php
+++ b/Tests/Functional/TemplateAnnotationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TemplateAnnotationTest extends WebTestCase
+{
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testController($url, $checkHtml)
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', $url);
+
+        $this->assertEquals($checkHtml, $crawler->filterXPath('//body')->html());
+    }
+
+    public static function urlProvider()
+    {
+        return array(
+            array('/multi/one-template/1/', 'bar'),
+            array('/multi/one-template/2/', 'bar'),
+            array('/multi/one-template/3/', 'bar'),
+            array('/multi/one-template/4/', 'foo bar baz'),
+            array('/invokable/predefined/service/', 'bar'),
+            array('/invokable/class-level/service/', 'bar'),
+            array('/simple/multiple/', 'a, b, c'),
+            array('/simple/multiple/henk/bar/', 'henk, bar, c'),
+            array('/simple/multiple-with-vars/', 'a, b'),
+            array('/invokable/predefined/container/', 'bar'),
+            array('/invokable/variable/container/the-var/', 'the-var'),
+            array('/invokable/another-variable/container/another-var/', 'another-var'),
+            array('/invokable/variable/container/the-var/another-var/', 'the-var,another-var'),
+            array('/no-listener/', 'I did not get rendered via twig'),
+            array('/streamed/', 'foo, bar'),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/dependency-injection": "~2.3|~3.0",
         "doctrine/common": "~2.2"
     },
     "require-dev": {
@@ -19,9 +20,10 @@
         "symfony/finder": "~2.3|~3.0",
         "symfony/security-bundle": "~2.4|~3.0",
         "symfony/twig-bundle": "~2.3|~3.0",
-        "twig/twig": "~1.23|~2.0",
+        "twig/twig": "~1.11|~2.0",
         "symfony/browser-kit": "~2.3|~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/dom-crawler": "~2.3|~3.0"
     },
     "suggest": {
         "symfony/psr-http-message-bridge": "To use the PSR-7 converters",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,12 @@
     },
     "require-dev": {
         "symfony/expression-language": "~2.4|~3.0",
-        "symfony/security-bundle": "~2.4|~3.0"
+        "symfony/finder": "~2.3|~3.0",
+        "symfony/security-bundle": "~2.4|~3.0",
+        "symfony/twig-bundle": "~2.3|~3.0",
+        "twig/twig": "~1.23|~2.0",
+        "symfony/browser-kit": "~2.3|~3.0",
+        "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {
         "symfony/psr-http-message-bridge": "To use the PSR-7 converters",
@@ -25,6 +30,9 @@
     },
     "autoload": {
         "psr-4": { "Sensio\\Bundle\\FrameworkExtraBundle\\": "" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Tests\\Fixtures\\": "Tests/Fixtures/" }
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,9 @@
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
-
+    <php>
+        <server name="KERNEL_DIR" value="Tests/Fixtures/"/>
+    </php>
     <filter>
         <whitelist>
             <directory>./</directory>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #385
| License       | MIT
| Doc PR        | ~

This PR aims to fix the issue where reflection was called to calculate the method signature (arguments) in the controller event. Those parameters were only ever used [if the controller returns "null" as response](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/v3.0.11/EventListener/TemplateListener.php#L95) in the view event. Instead of doing most of it in the controller event, this resolving is now done in the view event instead and prevents a reflection call in most cases. [Previously it was calculated here.](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/v3.0.11/EventListener/TemplateListener.php#L72)

Additionally I've fixed the issue reported here in #385. If you would pass no arguments and return null, it would never render and fail instead. Now it just renders the template without any additional parameters.

Because this class was untested, I've taken the liberty to add a bunch of functional tests that test most of the code (happy flow). I have not yet had time to properly test the unhappy flow and can be done if it's a requirement of the PR. Those tests should help with the annotations in general as also the `@Route` is tested here.

~~#388 is blocking the CI for php 5.5+~~