### PR TITLE
Allow multiple @Security

### DIFF
--- a/Configuration/Security.php
+++ b/Configuration/Security.php
@@ -43,6 +43,6 @@ class Security extends ConfigurationAnnotation
 
     public function allowArray()
     {
-        return false;
+        return true;
     }
 }

--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -48,7 +48,7 @@ class SecurityListener implements EventSubscriberInterface
     public function onKernelController(FilterControllerEvent $event)
     {
         $request = $event->getRequest();
-        if (!$configuration = $request->attributes->get('_security')) {
+        if (!$configurations = $request->attributes->get('_security')) {
             return;
         }
 
@@ -64,8 +64,10 @@ class SecurityListener implements EventSubscriberInterface
             throw new \LogicException('To use the @Security tag, you need to use the Security component 2.4 or newer and to install the ExpressionLanguage component.');
         }
 
-        if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {
-            throw new AccessDeniedException(sprintf('Expression "%s" denied access.', $configuration->getExpression()));
+        foreach ($configurations as $configuration) {
+            if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {
+                throw new AccessDeniedException(sprintf('Expression "%s" denied access.', $configuration->getExpression()));
+            }
         }
     }
 

--- a/Tests/EventListener/SecurityListenerTest.php
+++ b/Tests/EventListener/SecurityListenerTest.php
@@ -84,7 +84,10 @@ class SecurityListenerTest extends \PHPUnit_Framework_TestCase
     private function createRequest(Security $security = null)
     {
         return new Request(array(), array(), array(
-            '_security' => $security,
+            '_security' => array(
+                $security,
+                $security,
+            ),
         ));
     }
 


### PR DESCRIPTION
The current behavior is not cool because it allows user to use only one
`@Security` tag per action OR per class. BUT Nothing prevents user to put
a tag on the class AND another one on the action. And it's even worst
because only the tag on the action will be used.

Because almost all annotations allow multiple instances (like `@Route`,
`@Template`, `@Method`) I think it's really convenient to allow multiple
`@Security`, and more over to fix a bug.

I already see theses PR;
* https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/368
* https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/370

But they are not perfect.