### PR TITLE
EventListener type check error

### DIFF
--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
-use Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
following #285 
when setting expression_language to  "security.expression_language" will cause EventListener type check error.

```yaml
#config.yml

sensio_framework_extra:
    security:
        expression_language:  security.expression_language
```
