### PR TITLE
Allow to guess templates for controllers in a custom directory

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -72,6 +72,14 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enabled')->defaultValue(interface_exists('Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface'))->end()
                     ->end()
                 ->end()
+                ->arrayNode('templating')
+                    ->fixXmlConfig('controller_pattern')
+                    ->children()
+                        ->arrayNode('controller_patterns')
+                            ->prototype('scalar')
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -32,6 +32,12 @@ class SensioFrameworkExtraExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        if (!empty($config['templating']['controller_patterns'])) {
+            $container
+                ->getDefinition('sensio_framework_extra.view.guesser')
+                ->addArgument($config['templating']['controller_patterns']);
+        }
+
         $annotationsToLoad = array();
 
         if ($config['router']['annotations']) {

--- a/Templating/TemplateGuesser.php
+++ b/Templating/TemplateGuesser.php
@@ -30,22 +30,31 @@ class TemplateGuesser
     protected $kernel;
 
     /**
+     * @var string[]
+     */
+    private $controllerPatterns;
+
+    /**
      * Constructor.
      *
-     * @param KernelInterface $kernel A KernelInterface instance
+     * @param KernelInterface $kernel             A KernelInterface instance
+     * @param string[]        $controllerPatterns Regexps extracting the controller name from its FQN.
      */
-    public function __construct(KernelInterface $kernel)
+    public function __construct(KernelInterface $kernel, array $controllerPatterns = array())
     {
+        $controllerPatterns[] = '/Controller\\\(.+)Controller$/';
+
         $this->kernel = $kernel;
+        $this->controllerPatterns = $controllerPatterns;
     }
 
     /**
      * Guesses and returns the template name to render based on the controller
      * and action names.
      *
-     * @param array   $controller An array storing the controller object and action method
-     * @param Request $request    A Request instance
-     * @param string  $engine
+     * @param callable $controller An array storing the controller object and action method
+     * @param Request  $request    A Request instance
+     * @param string   $engine
      *
      * @return TemplateReference template reference
      *
@@ -53,13 +62,30 @@ class TemplateGuesser
      */
     public function guessTemplateName($controller, Request $request, $engine = 'twig')
     {
+        if (is_object($controller) && method_exists($controller, '__invoke')) {
+            $controller = array($controller, '__invoke');
+        } elseif (!is_array($controller)) {
+            throw new \InvalidArgumentException(sprintf('First argument of %s must be an array callable or an object defining the magic method __invoke. "%s" given.', __METHOD__, gettype($controller)));
+        }
+
         $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
 
-        if (!preg_match('/Controller\\\(.+)Controller$/', $className, $matchController)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" class does not look like a controller class (it must be in a "Controller" sub-namespace and the class name must end with "Controller")', get_class($controller[0])));
+        $matchController = null;
+        foreach ($this->controllerPatterns as $pattern) {
+            if (preg_match($pattern, $className, $tempMatch)) {
+                $matchController = $tempMatch;
+                break;
+            }
         }
-        if (!preg_match('/^(.+)Action$/', $controller[1], $matchAction)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" method does not look like an action method (it does not end with Action)', $controller[1]));
+        if (null === $matchController) {
+            throw new \InvalidArgumentException(sprintf('The "%s" class does not look like a controller class (its FQN must match one of the following regexps: "%s")', get_class($controller[0]), implode('", "', $this->controllerPatterns)));
+        }
+
+        if ($controller[1] === '__invoke') {
+            $matchAction = $matchController;
+            $matchController = null;
+        } elseif (!preg_match('/^(.+)Action$/', $controller[1], $matchAction)) {
+            $matchAction = array(null, $controller[1]);
         }
 
         $bundle = $this->getBundleForClass($className);

--- a/Tests/DependencyInjection/SensioFrameworkExtraExtensionTest.php
+++ b/Tests/DependencyInjection/SensioFrameworkExtraExtensionTest.php
@@ -87,6 +87,22 @@ class SensioFrameworkExtraExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertAlias($container, 'acme.security.expression_language', 'sensio_framework_extra.security.expression_language');
     }
 
+    public function testTemplatingControllerPatterns()
+    {
+        $container = new ContainerBuilder();
+
+        $extension = new SensioFrameworkExtraExtension();
+        $config = array(
+            'templating' => array(
+                'controller_patterns' => $patterns = array('/foo/', '/bar/', '/foobar/'),
+            ),
+        );
+
+        $extension->load(array($config), $container);
+
+        $this->assertEquals($patterns, $container->getDefinition('sensio_framework_extra.view.guesser')->getArgument(1));
+    }
+
     private function assertAlias(ContainerBuilder $container, $value, $key)
     {
         $this->assertEquals($value, (string) $container->getAlias($key), sprintf('%s alias is correct', $key));

--- a/Tests/Templating/Fixture/FooBundle/Action/FooAction.php
+++ b/Tests/Templating/Fixture/FooBundle/Action/FooAction.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Templating\Fixture\FooBundle\Action;
+
+class FooAction
+{
+}


### PR DESCRIPTION
@dunglas recently presented an ADR approach of the controllers with his [ActionBundle](https://github.com/dunglas/DunglasActionBundle).
But ``SensioFrameworkExtraBundle`` can't guess templates path when using it (see https://github.com/dunglas/DunglasActionBundle/issues/5).

So this PR tries to fix this. I'm wondering if this is enough or if we should provide something even more flexible (with a config parameter).