### PR TITLE
Remove the @Template owner after kernel.view

### DIFF
--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -115,6 +115,9 @@ class TemplateListener implements EventSubscriberInterface
             $event->setResponse(new StreamedResponse($callback));
         }
 
+        // make sure the owner (controller+dependencies) is not cached or stored elsewhere
+        $template->setOwner(array());
+
         $event->setResponse($templating->renderResponse($template->getTemplate(), $parameters));
     }
 


### PR DESCRIPTION
The issue is most likely that the owner is somehow cached or still referred at a point where it cannot be cleared properly. This will fix the reference but is not a permanent fix. This is something I can properly fix with symfony/symfony#17933.

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #402 
| License       | MIT
| Doc PR        | ~