### PR TITLE
Check the availibility of Zend Diactoros to auto-enable the PSR7 layer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -69,7 +69,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('psr_message')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->booleanNode('enabled')->defaultValue(interface_exists('Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface'))->end()
+                        ->booleanNode('enabled')->defaultValue(interface_exists('Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface') && class_exists('Zend\Diactoros\ServerRequestFactory'))->end()
                     ->end()
                 ->end()
                 ->arrayNode('templating')


### PR DESCRIPTION
As the bundle needs both factories of the bridge, it needs Zend Diactoros to be available too.

See https://github.com/symfony/psr-http-message-bridge/issues/20