### PR TITLE
ParamConverter - Switched options order

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -118,7 +118,7 @@ option::
 
     /**
      * @Route("/blog/{post_id}")
-     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"id" = "post_id"})
+     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"post_id" = "id"})
      */
     public function showAction(Post $post)
     {
@@ -133,7 +133,7 @@ This also allows you to have multiple converters in one action::
 
     /**
      * @Route("/blog/{id}/comments/{comment_id}")
-     * @ParamConverter("comment", class="SensioBlogBundle:Comment", options={"id" = "comment_id"})
+     * @ParamConverter("comment", class="SensioBlogBundle:Comment", options={"comment_id" = "id"})
      */
     public function showAction(Post $post, Comment $comment)
     {


### PR DESCRIPTION
After getting stuck while attempting to use the ParamConverter I realized the docs had the options order backwards.  I used a different example from online with the proposed changes and it works flawlessly. I re-tested it with the current options order that the docs say and it fails again.

P.S. This is my first docs commit so hopefully this isn't just an end-user error
