### PR TITLE
Fixed small typo in exception message

### DIFF
--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -61,7 +61,7 @@ class SecurityListener implements EventSubscriberInterface
         }
 
         if (null === $this->language) {
-            throw new \LogicException('To use the @Security tag, you need to use the Security component 2.4 or newer and to install the ExpressionLanguage component.');
+            throw new \LogicException('To use the @Security tag, you need to use the Security component 2.4 or newer and install the ExpressionLanguage component.');
         }
 
         if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {


### PR DESCRIPTION
Fixed a small typo in an exception message in `SecurityListener`.