### PR TITLE
Change ControllerListener to also load annotations from __invoke

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -50,7 +50,13 @@ class ControllerListener implements EventSubscriberInterface
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        if (!is_array($controller = $event->getController())) {
+        $controller = $event->getController();
+        
+        if (!is_array($controller) && method_exists($controller, '__invoke')) {
+            $controller = array($controller, '__invoke');
+        }
+        
+        if (!is_array($controller)) {
             return;
         }
 

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -51,11 +51,11 @@ class ControllerListener implements EventSubscriberInterface
     public function onKernelController(FilterControllerEvent $event)
     {
         $controller = $event->getController();
-        
+
         if (!is_array($controller) && method_exists($controller, '__invoke')) {
             $controller = array($controller, '__invoke');
         }
-        
+
         if (!is_array($controller)) {
             return;
         }


### PR DESCRIPTION
For controllers with an __invoke method, annotations are not loaded when not explicitely specifying the method in the _controller attribute.

This change will make sure to load the annotations from the __invoke method.

Fixes https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/338