### PR TITLE
Bug when using @Template in conjunction with @Cache

### DIFF
--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -67,7 +67,7 @@ class TemplateListener implements EventSubscriberInterface
 
         $controller = $event->getController();
         if (is_array($controller)) {
-          $template->setOwner($controller);
+            $template->setOwner($controller);
         }
 
         // when no template has been given, try to resolve it based on the controller

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -65,7 +65,10 @@ class TemplateListener implements EventSubscriberInterface
             throw new \InvalidArgumentException('Request attribute "_template" is reserved for @Template annotations.');
         }
 
-        $template->setOwner($controller = $event->getController());
+        $controller = $event->getController();
+        if (is_array($controller)) {
+          $template->setOwner($controller);
+        }
 
         // when no template has been given, try to resolve it based on the controller
         if (null === $template->getTemplate()) {

--- a/Tests/Fixtures/FooBundle/Controller/TemplateAndCacheController.php
+++ b/Tests/Fixtures/FooBundle/Controller/TemplateAndCacheController.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route(service="test.templateandcache")
+ */
+class TemplateAndCacheController
+{
+
+    /**
+    * @Route("/templateandcache")
+    * @Template()
+    * @Cache(etag="'ThisIsMyETAG'")
+    */
+    public function templateAndCacheAction()
+    {
+
+    }
+
+    /**
+    * @Route("/cacheonly")
+    * @Cache(etag="'ThisIsMyETAG'")
+    */
+    public function cacheOnlyAction()
+    {
+      return new Response('<html><body>This is to be cached</body></html>');
+    }
+
+}

--- a/Tests/Fixtures/FooBundle/Resources/views/TemplateAndCache/templateandcache.html.twig
+++ b/Tests/Fixtures/FooBundle/Resources/views/TemplateAndCache/templateandcache.html.twig
@@ -1,0 +1,1 @@
+<html><body>Template and cache</body></html>

--- a/Tests/Fixtures/config/config.yml
+++ b/Tests/Fixtures/config/config.yml
@@ -15,3 +15,6 @@ services:
 
     test.simple.multiple:
         class: Tests\Fixtures\FooBundle\Controller\SimpleController
+
+    test.templateandcache:
+        class: Tests\Fixtures\FooBundle\Controller\TemplateAndCacheController

--- a/Tests/Functional/TemplateAndCacheAnnotationTest.php
+++ b/Tests/Functional/TemplateAndCacheAnnotationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TemplateAnnotationTest extends WebTestCase
+{
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testTemplateAndCacheController($url)
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', $url, array(), array(), array('HTTP_If-None-Match' => sprintf('"%s"', hash('sha256', 'ThisIsMyETAG'))));
+
+        $this->assertEquals(304, $client->getResponse()->getStatusCode());
+    }
+
+    public static function urlProvider()
+    {
+        return array(
+            array('/templateandcache'),
+            array('/cacheonly'),
+        );
+    }
+}


### PR DESCRIPTION
When I use both @Template("...") and @Cache(lastModified="...") every 2 requests I am presented with an error.
It seems that $event->getController() returns a "Closure" object instead of an array and this causes an error to be thrown upon setOwner which takes only arrays.
Adding the check before the setOwner function is called prevents this error.
I wish I could write a test case to show the error but so far I am failing to get phpunit running with the functional test provided.