### PR TITLE
[WIP] Adding a smarter AnnotatedRoutingResource class

### DIFF
--- a/Config/AnnotatedRoutingResource.php
+++ b/Config/AnnotatedRoutingResource.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Config;
+
+class AnnotatedRoutingResource implements \Serializable
+{
+    private $class;
+    private $filePath;
+    private $annotationMetadata = array();
+
+    public function __construct($class, $path, array $annotationMetadata)
+    {
+        $this->class = $class;
+        $this->filePath = $path;
+        $this->annotationMetadata = $annotationMetadata;
+    }
+
+    public function __toString()
+    {
+        return 'routing.annotations.'.$this->class;
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->class, $this->filePath, $this->annotationMetadata));
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->class, $this->filePath, $this->annotationMetadata) = unserialize($serialized);
+    }
+
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    public function getFilePath()
+    {
+        return $this->filePath;
+    }
+}

--- a/Config/AnnotatedRoutingResourceChecker.php
+++ b/Config/AnnotatedRoutingResourceChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Config;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\ResourceCheckerInterface;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+
+class AnnotatedRoutingResourceChecker implements ResourceCheckerInterface
+{
+    private $annotationClassLoader;
+
+    public function __construct(AnnotationClassLoader $annotationClassLoader)
+    {
+        $this->annotationClassLoader = $annotationClassLoader;
+    }
+
+    public function supports(ResourceInterface $metadata)
+    {
+        return $metadata instanceof AnnotatedRoutingResource;
+    }
+
+    /**
+     * @param AnnotatedRoutingResource $resource
+     * @param int $timestamp
+     * @return bool
+     */
+    public function isFresh(ResourceInterface $resource, $timestamp)
+    {
+        if (!file_exists($resource->getFilePath())) {
+            return false;
+        }
+
+        // has the file *not* been modified? Definitely fresh
+        if (@filemtime($resource->getFilePath()) <= $timestamp) {
+            return true;
+        }
+
+        try {
+            $reflectionClass = new \ReflectionClass($resource->getClass());
+        } catch (\ReflectionException $e) {
+            // the class does not exist anymore!
+            return false;
+        }
+
+        return (array) $resource === (array) $this->annotationClassLoader->createResourceForClass($reflectionClass);
+    }
+
+}

--- a/Config/AnnotatedRoutingResourceChecker.php
+++ b/Config/AnnotatedRoutingResourceChecker.php
@@ -11,17 +11,17 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\Config;
 
+use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\Config\ResourceCheckerInterface;
-use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 
 class AnnotatedRoutingResourceChecker implements ResourceCheckerInterface
 {
-    private $annotationClassLoader;
+    private $reader;
 
-    public function __construct(AnnotationClassLoader $annotationClassLoader)
+    public function __construct(Reader $reader)
     {
-        $this->annotationClassLoader = $annotationClassLoader;
+        $this->reader = $reader;
     }
 
     public function supports(ResourceInterface $metadata)
@@ -52,7 +52,9 @@ class AnnotatedRoutingResourceChecker implements ResourceCheckerInterface
             return false;
         }
 
-        return (array) $resource === (array) $this->annotationClassLoader->createResourceForClass($reflectionClass);
+        $newResource = new AnnotatedRoutingResource($reflectionClass, $this->reader);
+
+        return (array) $resource === (array) $newResource;
     }
 
 }

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -27,5 +27,10 @@
             <tag name="routing.loader" />
             <argument type="service" id="annotation_reader" />
         </service>
+
+        <service id="sensio_framework_extra.config.annot_routing_resource_checker" class="Sensio\Bundle\FrameworkExtraBundle\Config\AnnotatedRoutingResourceChecker" public="false">
+            <tag name="config_cache.resource_checker" priority="-900" />
+            <argument type="service" id="annotation_reader" />
+        </service>
     </services>
 </container>

--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -105,24 +105,6 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
      */
     protected function createConfigResource(\ReflectionClass $class)
     {
-        $classAnnotations = $this->reader->getClassAnnotations($class);
-
-        $methodAnnotations = array();
-        foreach ($class->getMethods() as $method) {
-            $this->defaultRouteIndex = 0;
-            $methodAnnotations[$method->name] = [];
-            foreach ($this->reader->getMethodAnnotations($method) as $annot) {
-                $methodAnnotations[$method->name][] = $annot;
-            }
-        }
-
-        $metadata = array(
-            // cast to an array, as a convenient way to get a "fingerprint"
-            // of all of the properties on the annotations objects
-            'class_annotations' => (array) $classAnnotations,
-            'method_annotations' => (array) $methodAnnotations,
-        );
-
-        return new AnnotatedRoutingResource($class->name, $class->getFileName(), $metadata);
+        return new AnnotatedRoutingResource($class, $this->reader);
     }
 }


### PR DESCRIPTION
Currently, if the file modified time of a controller class is updated, then the cache is marked as stale and all of the routes are rebuilt.

With this addition, a cached resource would only be stale if an annotation has actually changed. This will prevent the route cache from being rebuilt as you're simply building the PHP code in your controller.

Todo
* [ ] Open PR to Symfony's core to support this
* [ ] Add tests (need the above to do that)
