### PR TITLE
Fix error when returning a 304 (not calling template listener) + phpunit

### DIFF
--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -65,6 +65,7 @@ class HttpCacheListener implements EventSubscriberInterface
             $event->setController(function () use ($response) {
                 return $response;
             });
+            $event->stopPropagation();
         } else {
             if ($etag) {
                 $this->etags[$request] = $etag;

--- a/Tests/EventListener/HttpCacheListenerTest.php
+++ b/Tests/EventListener/HttpCacheListenerTest.php
@@ -101,7 +101,7 @@ class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($vary, $result, 'Vary header should not be changed');
     }
 
-    public function testResponseIsNeitherPrivateNorPublicIfConfigurationIsPublicNotSet()
+    public function testResponseIsPrivateIfConfigurationIsPublicNotSet()
     {
         $request = $this->createRequest(new Cache(array(
         )));
@@ -109,7 +109,7 @@ class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
 
         $this->assertFalse($this->response->headers->hasCacheControlDirective('public'));
-        $this->assertFalse($this->response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
     }
 
     public function testConfigurationAttributesAreSetOnResponse()


### PR DESCRIPTION
Hi,

Since this PR https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/420 wasn't really accepted i'm submitting another PR with the use of the stopPropagation (works as well).

This should fix this issue : https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/421

And i fixed an unit test as well which was broken by this commit : https://github.com/symfony/http-foundation/commit/295423690c79e35a59d2aecdc7fb1511171d0c96 (it forces private as default)

