### PR TITLE
Adding a new expr option for the Doctrine param converter

### DIFF
--- a/Configuration/Entity.php
+++ b/Configuration/Entity.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
+
+/**
+ * Doctrine-specific ParamConverter with an easier syntax.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ * @Annotation
+ */
+class Entity extends ParamConverter
+{
+    public function setExpr($expr)
+    {
+        $options = $this->getOptions();
+        $options['expr'] = $expr;
+
+        $this->setOptions($options);
+    }
+}

--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -41,6 +41,12 @@ class SensioFrameworkExtraExtension extends Extension
         if ($config['router']['annotations']) {
             $annotationsToLoad[] = 'routing.xml';
 
+            if (class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage') && class_exists('Symfony\Component\Security\Core\Authorization\ExpressionLanguage')) {
+                $container->setAlias('sensio_framework_extra.converter.doctrine.orm.expression_language', new Alias('sensio_framework_extra.converter.doctrine.orm.expression_language.default', false));
+            } else {
+                $container->removeDefinition('sensio_framework_extra.converter.doctrine.orm.expression_language.default');
+            }
+
             $this->addClassesToCompile(array(
                 'Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\ControllerListener',
             ));

--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -41,12 +41,6 @@ class SensioFrameworkExtraExtension extends Extension
         if ($config['router']['annotations']) {
             $annotationsToLoad[] = 'routing.xml';
 
-            if (class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage') && class_exists('Symfony\Component\Security\Core\Authorization\ExpressionLanguage')) {
-                $container->setAlias('sensio_framework_extra.converter.doctrine.orm.expression_language', new Alias('sensio_framework_extra.converter.doctrine.orm.expression_language.default', false));
-            } else {
-                $container->removeDefinition('sensio_framework_extra.converter.doctrine.orm.expression_language.default');
-            }
-
             $this->addClassesToCompile(array(
                 'Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\ControllerListener',
             ));
@@ -54,6 +48,12 @@ class SensioFrameworkExtraExtension extends Extension
 
         if ($config['request']['converters']) {
             $annotationsToLoad[] = 'converters.xml';
+
+            if (class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
+                $container->setAlias('sensio_framework_extra.converter.doctrine.orm.expression_language', new Alias('sensio_framework_extra.converter.doctrine.orm.expression_language.default', false));
+            } else {
+                $container->removeDefinition('sensio_framework_extra.converter.doctrine.orm.expression_language.default');
+            }
 
             $this->addClassesToCompile(array(
                 // cannot be added because it has some annotations

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -281,6 +281,15 @@ class DoctrineParamConverter implements ParamConverterInterface
         );
 
         $passedOptions = $configuration->getOptions();
+
+        if (isset($passedOptions['repository_method'])) {
+            @trigger_error('The repository_method option of @ParamConverter is deprecated and will be removed in 5.0. Use the expr option or @Entity.', E_USER_DEPRECATED);
+        }
+
+        if (isset($passedOptions['map_method_signature'])) {
+            @trigger_error('The map_method_signature option of @ParamConverter is deprecated and will be removed in 5.0. Use the expr option or @Entity.', E_USER_DEPRECATED);
+        }
+
         $extraKeys = array_diff(array_keys($passedOptions), array_keys($defaultValues));
         if ($extraKeys) {
             throw new \InvalidArgumentException(sprintf('Invalid option(s) passed to @ParamConverter: %s', implode(', ', $extraKeys)));

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -233,8 +233,6 @@ class DoctrineParamConverter implements ParamConverterInterface
 
         try {
             return $this->language->evaluate($expression, $variables);
-
-            // execute it here
         } catch (NoResultException $e) {
             return;
         } catch (SyntaxError $e) {

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -79,7 +79,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
 
         if (null === $object && false === $configuration->isOptional()) {
-            $message = sprintf('%s object not found.', $class);
+            $message = sprintf('%s object not found by the @ParamConverter annotation.', $class);
             if ($errorMessage) {
                 $message .= ' '.$errorMessage;
             }

--- a/Resources/config/converters.xml
+++ b/Resources/config/converters.xml
@@ -16,10 +16,13 @@
         <service id="sensio_framework_extra.converter.doctrine.orm" class="Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter">
             <tag name="request.param_converter" converter="doctrine.orm" />
             <argument type="service" id="doctrine" on-invalid="ignore" />
+            <argument type="service" id="sensio_framework_extra.converter.doctrine.orm.expression_language" on-invalid="null" />
         </service>
 
         <service id="sensio_framework_extra.converter.datetime" class="Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DateTimeParamConverter">
             <tag name="request.param_converter" converter="datetime" />
         </service>
+
+        <service id="sensio_framework_extra.converter.doctrine.orm.expression_language.default" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" public="false" />
     </services>
 </container>

--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -85,33 +85,21 @@ Doctrine Converter
 Converter Name: ``doctrine.orm``
 
 The Doctrine Converter attempts to convert request attributes to Doctrine
-entities fetched from the database. Two different approaches are possible:
+entities fetched from the database. Three different approaches are possible:
 
+- Fetch via an expression.
 - Fetch object by primary key.
 - Fetch object by one or several fields which contain unique values in the
   database.
 
 The following algorithm determines which operation will be performed.
 
+- If your annotation has an ``expr`` option, this is always - and only - used.
 - If an ``{id}`` parameter is present in the route, find object by primary key.
 - If an option ``'id'`` is configured and matches route parameters, find object by primary key.
 - If the previous rules do not apply, attempt to find one entity by matching
   route parameters to entity fields. You can control this process by
   configuring ``exclude`` parameters or a attribute to field name ``mapping``.
-
-By default, the Doctrine converter uses the *default* entity manager. This can
-be configured with the ``entity_manager`` option::
-
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-
-    /**
-     * @Route("/blog/{id}")
-     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"entity_manager" = "foo"})
-     */
-    public function showAction(Post $post)
-    {
-    }
 
 If the placeholder does not have the same name as the primary key, pass the ``id``
 option::
@@ -209,6 +197,20 @@ the ``map_method_signature`` option to true. The default is false::
 
    When ``map_method_signature`` is ``true``, the ``firstName`` and
    ``lastName`` parameters do not have to be Doctrine fields.
+
+By default, the Doctrine converter uses the *default* entity manager. This can
+be configured with the ``entity_manager`` option::
+
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+    /**
+     * @Route("/blog/{id}")
+     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"entity_manager" = "foo"})
+     */
+    public function showAction(Post $post)
+    {
+    }
 
 DateTime Converter
 ~~~~~~~~~~~~~~~~~~

--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -85,66 +85,115 @@ Doctrine Converter
 Converter Name: ``doctrine.orm``
 
 The Doctrine Converter attempts to convert request attributes to Doctrine
-entities fetched from the database. Three different approaches are possible:
+entities fetched from the database. Several different approaches are possible:
 
-- Fetch via an expression.
-- Fetch object by primary key.
-- Fetch object by one or several fields which contain unique values in the
-  database.
+1) Fetch Automatically
+......................
 
-The following algorithm determines which operation will be performed.
-
-- If your annotation has an ``expr`` option, this is always - and only - used.
-- If an ``{id}`` parameter is present in the route, find object by primary key.
-- If an option ``'id'`` is configured and matches route parameters, find object by primary key.
-- If the previous rules do not apply, attempt to find one entity by matching
-  route parameters to entity fields. You can control this process by
-  configuring ``exclude`` parameters or a attribute to field name ``mapping``.
-
-If the placeholder does not have the same name as the primary key, pass the ``id``
-option::
+If your route wildcards match properties on your entity, then
+the converter will automatically fetch them::
 
     /**
-     * @Route("/blog/{post_id}")
-     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"id" = "post_id"})
+     * Fetch via primary key because {id} is in the route.
+     *
+     * @Route("/blog/{id}")
+     */
+    public function showByPkAction(Post $post)
+    {
+    }
+
+    /**
+     * Perform a findOneBy() where the slug property matches {slug}.
+     *
+     * @Route("/blog/{slug}")
      */
     public function showAction(Post $post)
     {
     }
 
+Automatic fetching works in these situations:
+
+* If ``{id}`` is in your route, then this is used to fetch by
+  primary key via the ``find()`` method.
+
+* The converter will attempt to do a ``findOneBy()`` fetch by using
+  *all* of the wildcards in your route that are actually properties
+  on your entity (non-properties are ignored).
+
+You can control this behavior by actually *adding* the ``@ParamConverter``
+annotation and using the `@ParamConverter options`_.
+
+2) Fetch via an Expression
+..........................
+
+If automatic fetching doesn't work, another great option is to use
+an expression::
+
+    /**
+     * @Route("/blog/{post_id}")
+     * @Entity("post", expr="repository.find(post_id)")
+     */
+    public function showAction(Post $post)
+    {
+    }
+
+Use the special ``@Entity`` annotation with an ``expr`` option to
+fetch the object by calling a method on your repository. The
+``repository`` method will be your entity's Repository class and
+any route wildcards - like ``{post_id}`` are available as variables.
+
 .. tip::
 
-   The ``id`` option specifies which placeholder from the route gets passed to the repository
-   method used. If no repository method is specified, ``find()`` is used by default.
+    The ``@Entity`` annotation is a shortcut for using ``expr``
+    and has all the same options as ``@ParamConverter``.
 
-This also allows you to have multiple converters in one action::
+This can also be used to help resolve multiple arguments::
 
     /**
      * @Route("/blog/{id}/comments/{comment_id}")
-     * @ParamConverter("comment", class="SensioBlogBundle:Comment", options={"id" = "comment_id"})
+     * @Entity("comment", expr="repository.find(comment_id)")
      */
     public function showAction(Post $post, Comment $comment)
     {
     }
 
-In the example above, the ``$post`` parameter is handled automatically, but ``$comment`` is
-configured with the annotation since they can not both follow the default convention.
+In the example above, the ``$post`` parameter is handled automatically, but ``$comment``
+is configured with the annotation since they cannot both follow the default convention.
 
-If you want to match an entity using multiple fields use the ``mapping`` hash
-option: the key is route placeholder name and the value is the Doctrine
-field name::
+.. _`@ParamConverter options`:
+
+DoctrineConverter Options
+.........................
+
+A number of ``options`` are available on the ``@ParamConverter`` or
+(``@Entity``) annotation to control behavior:
+
+* ``id``: If an ``id`` option is configured and matches a route parameter, then the
+  converter will find by the primary key::
+
+    /**
+     * @Route("/blog/{post_id}")
+     * @ParamConverter("post", options={"id" = "post_id"})
+     */
+    public function showPostAction(Post $post)
+    {
+    }
+
+* ``mapping``: Configures the properties and values to use with the ``findOneBy()``
+  method: the key is the route placeholder name and the value is the Doctrine property
+  name::
 
     /**
      * @Route("/blog/{date}/{slug}/comments/{comment_slug}")
      * @ParamConverter("post", options={"mapping": {"date": "date", "slug": "slug"}})
      * @ParamConverter("comment", options={"mapping": {"comment_slug": "slug"}})
      */
-    public function showAction(Post $post, Comment $comment)
+    public function showCommentAction(Post $post, Comment $comment)
     {
     }
 
-If you are matching an entity using several fields, but you want to exclude a
-route parameter from being part of the criteria::
+* ``exclude`` Configures the properties that should be used in the ``findOneBy()``
+  method by *excluding* one or more properties so that not *all* are used::
 
     /**
      * @Route("/blog/{date}/{slug}")
@@ -154,59 +203,15 @@ route parameter from being part of the criteria::
     {
     }
 
-If you want to specify the repository method to use to find the entity (for example,
-to add joins to the query), you can add the ``repository_method`` option::
+* ``strip_null`` If true, then when ``findOneBy()`` is used, any values that are
+  ``null`` will not be used for the query.
+
+* ``entity_manager`` By default, the Doctrine converter uses the *default* entity
+  manager, but you can configure this::
 
     /**
      * @Route("/blog/{id}")
-     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"repository_method" = "findWithJoins"})
-     */
-    public function showAction(Post $post)
-    {
-    }
-
-The specified repository method will be called with the criteria in an ``array``
-as parameter. This is a good fit with Doctrine's ``findBy`` and ``findOneBy``
-methods.
-
-There are cases where you want to you use your own repository method and you
-want to map the criteria to the method signature. This is possible when you set
-the ``map_method_signature`` option to true. The default is false::
-
-    /**
-     * @Route("/user/{first_name}/{last_name}")
-     * @ParamConverter("user", class="AcmeBlogBundle:User", options={
-     *    "repository_method" = "findByFullName",
-     *    "mapping": {"first_name": "firstName", "last_name": "lastName"},
-     *    "map_method_signature" = true
-     * })
-     */
-    public function showAction(User $user)
-    {
-    }
-
-    class UserRepository
-    {
-        public function findByFullName($firstName, $lastName)
-        {
-            ...
-        }
-    }
-
-.. tip::
-
-   When ``map_method_signature`` is ``true``, the ``firstName`` and
-   ``lastName`` parameters do not have to be Doctrine fields.
-
-By default, the Doctrine converter uses the *default* entity manager. This can
-be configured with the ``entity_manager`` option::
-
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-
-    /**
-     * @Route("/blog/{id}")
-     * @ParamConverter("post", class="SensioBlogBundle:Post", options={"entity_manager" = "foo"})
+     * @ParamConverter("post", options={"entity_manager" = "foo"})
      */
     public function showAction(Post $post)
     {

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -507,7 +507,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
 
         $objectManager->expects($this->once())
             ->method('getRepository')
@@ -541,7 +541,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
 
         $objectManager->expects($this->once())
             ->method('getRepository')
@@ -583,7 +583,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
 
         $objectManager->expects($this->once())
             ->method('getRepository')

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -559,7 +559,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
             ->method('evaluate')
             ->with('repository.findOneByCustomMethod(id)', array(
                 'repository' => $objectRepository,
-                'id' => 5
+                'id' => 5,
             ))
             ->will($this->returnValue('new_mapped_value'));
 

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -11,6 +11,8 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter;
 
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -23,6 +25,11 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
     private $registry;
 
     /**
+     * @var ExpressionLanguage
+     */
+    private $language;
+
+    /**
      * @var DoctrineParamConverter
      */
     private $converter;
@@ -30,7 +37,8 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
-        $this->converter = new DoctrineParamConverter($this->registry);
+        $this->language = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionLanguage')->getMock();
+        $this->converter = new DoctrineParamConverter($this->registry, $this->language);
     }
 
     public function createConfiguration($class = null, array $options = null, $name = 'arg', $isOptional = false)
@@ -464,5 +472,135 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $ret = $this->converter->supports($config);
 
         $this->assertTrue($ret, 'Should be supported');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testExceptionWithExpressionIfNoLanguageAvailable()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration(
+            'stdClass',
+            array(
+                'expr' => 'repository.find(id)',
+            ),
+            'arg1'
+        );
+
+        $converter = new DoctrineParamConverter($this->registry);
+        $converter->apply($request, $config);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testExpressionFailureReturns404()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration(
+            'stdClass',
+            array(
+                'expr' => 'repository.someMethod()',
+            ),
+            'arg1'
+        );
+
+        $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence')->getMock();
+
+        $objectManager->expects($this->once())
+            ->method('getRepository')
+            ->will($this->returnValue($objectRepository));
+
+        // find should not be attempted on this repository as a fallback
+        $objectRepository->expects($this->never())
+            ->method('find');
+
+        $this->registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->will($this->returnValue($objectManager));
+
+        $this->language->expects($this->once())
+            ->method('evaluate')
+            ->will($this->returnValue(null));
+
+        $this->converter->apply($request, $config);
+    }
+
+    public function testExpressionMapsToArgument()
+    {
+        $request = new Request();
+        $request->attributes->set('id', 5);
+        $config = $this->createConfiguration(
+            'stdClass',
+            array(
+                'expr' => 'repository.findOneByCustomMethod(id)',
+            ),
+            'arg1'
+        );
+
+        $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence')->getMock();
+
+        $objectManager->expects($this->once())
+            ->method('getRepository')
+            ->will($this->returnValue($objectRepository));
+
+        // find should not be attempted on this repository as a fallback
+        $objectRepository->expects($this->never())
+            ->method('find');
+
+        $this->registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->will($this->returnValue($objectManager));
+
+        $this->language->expects($this->once())
+            ->method('evaluate')
+            ->with('repository.findOneByCustomMethod(id)', array(
+                'repository' => $objectRepository,
+                'id' => 5
+            ))
+            ->will($this->returnValue('new_mapped_value'));
+
+        $this->converter->apply($request, $config);
+        $this->assertEquals('new_mapped_value', $request->attributes->get('arg1'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage syntax error message around position 10
+     */
+    public function testExpressionSyntaxErrorThrowsException()
+    {
+        $request = new Request();
+        $config = $this->createConfiguration(
+            'stdClass',
+            array(
+                'expr' => 'repository.findOneByCustomMethod(id)',
+            ),
+            'arg1'
+        );
+
+        $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence')->getMock();
+
+        $objectManager->expects($this->once())
+            ->method('getRepository')
+            ->will($this->returnValue($objectRepository));
+
+        // find should not be attempted on this repository as a fallback
+        $objectRepository->expects($this->never())
+            ->method('find');
+
+        $this->registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->will($this->returnValue($objectManager));
+
+        $this->language->expects($this->once())
+            ->method('evaluate')
+            ->will($this->throwException(new SyntaxError('syntax error message', 10)));
+
+        $this->converter->apply($request, $config);
     }
 }

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -262,6 +262,9 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($object, $request->attributes->get('arg'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testApplyWithRepositoryMethod()
     {
         $request = new Request();
@@ -293,6 +296,9 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($className, $request->attributes->get('arg'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testApplyWithRepositoryMethodAndMapping()
     {
         $request = new Request();
@@ -340,6 +346,9 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($className, $request->attributes->get('arg'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testApplyWithRepositoryMethodAndMapMethodSignature()
     {
         $request = new Request();
@@ -382,6 +391,7 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Repository method "Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter\TestUserRepository::findByFullName" requires that you provide a value for the "$lastName" argument.
+     * @group legacy
      */
     public function testApplyWithRepositoryMethodAndMapMethodSignatureException()
     {

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -620,11 +620,11 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidOptionThrowsException()
     {
-        $configuration = new ParamConverter([
-            'options' => [
-                'fake_option' => []
-            ]
-        ]);
+        $configuration = new ParamConverter(array(
+            'options' => array(
+                'fake_option' => array(),
+            ),
+        ));
 
         $this->converter->apply(new Request(), $configuration);
     }

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\HttpFoundation\Request;
@@ -602,5 +603,19 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
             ->will($this->throwException(new SyntaxError('syntax error message', 10)));
 
         $this->converter->apply($request, $config);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidOptionThrowsException()
+    {
+        $configuration = new ParamConverter([
+            'options' => [
+                'fake_option' => []
+            ]
+        ]);
+
+        $this->converter->apply(new Request(), $configuration);
     }
 }


### PR DESCRIPTION
Fulfills #321 

This simply extends the `DoctrineParamConverter`, allowing for this:

```php
/**
 * @Route("/post/{slug}")
 * @ParamConverter("post", options={"expr":"repository.findOneBySlug(slug)"})
 */
public function showAction(Post $post)
```

Of course, `options` is super ugly :). So I've sub-classed `ParamConverter` with a type that simply makes setting the `expr` option much nicer:

```php
/**
 * @Route("/post/{slug}")
 * @Entity("post", expr="repository.findOneBySlug(slug)")
 */
public function showAction(Post $post)
```

All request attributes become variables + `repository` are variables in the expression. No expression functions were added... because I think it's just this simple. All existing functionality is unchanged. In fact, in this example,  you probably don't even need the annotation, since `slug` is probably the field name.

P.S. This is compatible/consistent with the version 4 changes in #431.

Cheers!