### PR TITLE
Adding a new @IsGranted() annotation for checking security

### DIFF
--- a/Configuration/IsGranted.php
+++ b/Configuration/IsGranted.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
+
+/**
+ * The Security class handles the Security annotation.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ * @Annotation
+ */
+class IsGranted extends ConfigurationAnnotation
+{
+    /**
+     * Sets the first argument that will be passed to isGranted().
+     *
+     * @var mixed
+     */
+    private $attributes;
+
+    /**
+     * Sets the second argument passed to isGranted().
+     *
+     * @var mixed
+     */
+    private $subject;
+
+    /**
+     * The message of the exception - has a nice default if not set.
+     *
+     * @var string
+     */
+    private $message;
+
+    /**
+     * If set, will throw Symfony\Component\HttpKernel\Exception\HttpException
+     * with the given $statusCode.
+     * If null, Symfony\Component\Security\Core\Exception\AccessDeniedException.
+     * will be used.
+     *
+     * @var int|null
+     */
+    private $statusCode;
+
+    public function setAttributes($attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    public function setStatusCode($statusCode)
+    {
+        $this->statusCode = $statusCode;
+    }
+
+    public function setValue($value)
+    {
+        $this->setAttributes($value);
+    }
+
+    public function getAliasName()
+    {
+        return 'is_granted';
+    }
+
+    public function allowArray()
+    {
+        return true;
+    }
+}

--- a/EventListener/IsGrantedListener.php
+++ b/EventListener/IsGrantedListener.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Handles the IsGranted annotation on controllers.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class IsGrantedListener implements EventSubscriberInterface
+{
+    private $authChecker;
+
+    public function __construct(AuthorizationCheckerInterface $authChecker = null)
+    {
+        $this->authChecker = $authChecker;
+    }
+
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $request = $event->getRequest();
+        /** @var $configurations IsGranted[] */
+        if (!$configurations = $request->attributes->get('_is_granted')) {
+            return;
+        }
+
+        if (null === $this->authChecker) {
+            throw new \LogicException('To use the @IsGranted tag, you need to install symfony/security-bundle.');
+        }
+
+        foreach ($configurations as $configuration) {
+            $subject = null;
+            if ($configuration->getSubject()) {
+                if (!$request->attributes->has($configuration->getSubject())) {
+                    $allAttributes = $request->attributes->all();
+                    // remove one attribute we know is noise in the error message
+                    unset($allAttributes['_is_granted']);
+                    throw new \RuntimeException(sprintf('Could not find the subject "%s" for the @IsGranted annotation. Available attributes are: %s', $configuration->getSubject(), implode(', ', array_keys($allAttributes))));
+                }
+
+                $subject = $request->attributes->get($configuration->getSubject());
+            }
+
+            if (!$this->authChecker->isGranted($configuration->getAttributes(), $subject)) {
+                $argsString = $this->getIsGrantedString($configuration);
+
+                $message = $configuration->getMessage() ?: sprintf('Access Denied by controller annotation @IsGranted(%s)', $argsString);
+
+                if ($statusCode = $configuration->getStatusCode()) {
+                    throw new HttpException($statusCode, $message);
+                }
+
+                throw new AccessDeniedException($message);
+            }
+        }
+    }
+
+    private function getIsGrantedString(IsGranted $isGranted)
+    {
+        $attributes = array_map(function ($attribute) {
+            return sprintf('"%s"', $attribute);
+        }, (array) $isGranted->getAttributes());
+        if (1 === count($attributes)) {
+            $argsString = reset($attributes);
+        } else {
+            $argsString = sprintf('[%s]', implode(', ', $attributes));
+        }
+
+        if (null !== $isGranted->getSubject()) {
+            $argsString = sprintf('%s, %s', $argsString, $isGranted->getSubject());
+        }
+
+        return $argsString;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(KernelEvents::CONTROLLER => 'onKernelController');
+    }
+}

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -15,5 +15,10 @@
         </service>
 
         <service id="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" class="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" public="false" />
+
+        <service id="Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener" class="Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener" public="false">
+            <argument type="service" id="security.authorization_checker" on-invalid="null" />
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/Resources/doc/annotations/security.rst
+++ b/Resources/doc/annotations/security.rst
@@ -1,27 +1,82 @@
-@Security
-=========
-
-.. caution::
-
-    The ``@Security`` annotation only works as of Symfony 2.4.
+@Security & @IsGranted
+======================
 
 Usage
 -----
 
-The ``@Security`` annotation restricts access on controllers::
+The ``@Security`` and ``@IsGranted`` annotations restrict access on controllers::
 
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 
     class PostController extends Controller
     {
         /**
-         * @Security("has_role('ROLE_ADMIN')")
+         * @IsGranted("ROLE_ADMIN")
+         *
+         * or use @Security for more flexibility:
+         *
+         * @Security("is_granted('ROLE_ADMIN') and is_granted('ROLE_FRIENDLY_USER')")
          */
         public function indexAction()
         {
             // ...
         }
     }
+
+@IsGranted
+----------
+
+The ``@IsGranted()`` annotation is the simplest way to restrict access.
+Use it to restrict by roles, or use custom voters to restrict access based
+on variables passed to the controller::
+
+    /**
+     * @Route("/posts/{id}")
+     *
+     * @IsGranted("ROLE_ADMIN")
+     * @IsGranted("POST_SHOW", subject="post")
+     */
+    public function showAction(Post $post)
+    {
+    }
+
+Each ``IsGranted()`` must grant access for the user to have access to the controller.
+
+.. tip::
+
+    The ``@IsGranted("POST_SHOW", subject="post")`` is an example of using
+    a custom security voter. For more details, see `the Security Voters page`_.
+
+You can also control the message and status code::
+
+    /**
+     * Will throw a normal AccessDeniedException:
+     *
+     * @IsGranted("ROLE_ADMIN", message="No access! Get out!")
+     *
+     * Will throw an HttpException with a 404 status code:
+     *
+     * @IsGranted("ROLE_ADMIN", statusCode=404, message="Post not found")
+     */
+    public function showAction(Post $post)
+    {
+    }
+
+@Security
+---------
+
+The ``@Security`` annotation is more flexible than ``@IsGranted``: it
+allows you to pass an *expression* that can contains custom logic::
+
+    /**
+     * @Security("is_granted('ROLE_ADMIN') and is_granted('POST_SHOW', post)")
+     */
+    public function showAction(Post $post)
+    {
+        // ...
+    }
+
 
 The expression can use all functions that you can use in the ``access_control``
 section of the security bundle configuration, with the addition of the
@@ -35,25 +90,6 @@ The expression has access to the following variables:
 * ``roles``: The user roles;
 * and all request attributes.
 
-The ``is_granted()`` function allows you to restrict access based on variables
-passed to the controller::
-
-    /**
-     * @Security("is_granted('POST_SHOW', post)")
-     */
-    public function showAction(Post $post)
-    {
-    }
-
-Here is another example, making use of multiple functions in the expression::
-
-    /**
-     * @Security("is_granted('POST_SHOW', post) and has_role('ROLE_ADMIN')")
-     */
-    public function showAction(Post $post)
-    {
-    }
-
 You can throw an ``Symfony\Component\HttpKernel\Exception\HttpException``
 exception instead of
 ``Symfony\Component\Security\Core\Exception\AccessDeniedException`` using the
@@ -66,7 +102,7 @@ exception instead of
     {
     }
 
-The ``message`` option allows to customize the exception message::
+The ``message`` option allows you to customize the exception message::
 
     /**
      * @Security("is_granted('POST_SHOW', post)", statusCode=404, message="Resource not found.")
@@ -75,15 +111,9 @@ The ``message`` option allows to customize the exception message::
     {
     }
 
-.. note::
-
-    Defining a ``Security`` annotation has the same effect as defining an
-    access control rule, but it is more efficient as the check is only done
-    when this specific route is accessed. To create new access control
-    rules, please refer to `the Security Voters page`_.
-
 .. tip::
 
-    You can also add a ``@Security`` annotation on a controller class.
+    You can also add ``@IsGranted`` or  ``@Security`` annotations on a controller
+    class to prevent access to *all* actions in the class.
 
 .. _`the Security Voters page`: http://symfony.com/doc/current/cookbook/security/voters_data_permission.html

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -113,6 +113,7 @@ This example shows all the available annotations in action::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
     /**
@@ -138,6 +139,7 @@ This example shows all the available annotations in action::
          * @ParamConverter("post", class="SensioBlogBundle:Post")
          * @Template("SensioBlogBundle:Annot:show.html.twig", vars={"post"})
          * @Cache(smaxage="15", lastmodified="post.getUpdatedAt()", etag="'Post' ~ post.getId() ~ post.getUpdatedAt()")
+         * @IsGranted("ROLE_SPECIAL_USER")
          * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)")
          */
         public function showAction(Post $post)
@@ -151,6 +153,7 @@ annotations::
     /**
      * @Route("/{id}")
      * @Cache(smaxage="15", lastModified="post.getUpdatedAt()", Etag="'Post' ~ post.getId() ~ post.getUpdatedAt()")
+     * @IsGranted("ROLE_SPECIAL_USER")
      * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)")
      */
     public function showAction(Post $post)

--- a/Tests/EventListener/IsGrantedListenerTest.php
+++ b/Tests/EventListener/IsGrantedListenerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class IsGrantedListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testExceptionIfSecurityNotInstalled()
+    {
+        $listener = new IsGrantedListener();
+        $request = $this->createRequest(new IsGranted(array()));
+        $listener->onKernelController($this->createFilterControllerEvent($request));
+    }
+
+    public function testNothingHappensWithNoConfig()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        $authChecker->expects($this->never())
+            ->method('isGranted');
+
+        $listener = new IsGrantedListener($authChecker);
+        $request = $this->createRequest();
+        $listener->onKernelController($this->createFilterControllerEvent($request));
+    }
+
+    public function testIsGrantedCalledCorrectly()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        // createRequest() puts 2 IsGranted annotations into the config
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            ->with('ROLE_ADMIN', 'bar')
+            ->will($this->returnValue(true));
+
+        $listener = new IsGrantedListener($authChecker);
+        $isGranted = new IsGranted(array('attributes' => 'ROLE_ADMIN', 'subject' => 'foo'));
+        $request = $this->createRequest($isGranted);
+        $request->attributes->set('foo', 'bar');
+        $listener->onKernelController($this->createFilterControllerEvent($request));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testExceptionWhenMissingSubjectAttribute()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+
+        $listener = new IsGrantedListener($authChecker);
+        $isGranted = new IsGranted(array('attributes' => 'ROLE_ADMIN', 'subject' => 'non_existent'));
+        $request = $this->createRequest($isGranted);
+        $listener->onKernelController($this->createFilterControllerEvent($request));
+    }
+
+    /**
+     * @dataProvider getAccessDeniedMessageTests
+     */
+    public function testAccessDeniedMessages(array $attributes, $subject, $expectedMessage)
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        $authChecker->expects($this->any())
+            ->method('isGranted')
+            ->will($this->returnValue(false));
+
+        $listener = new IsGrantedListener($authChecker);
+        $isGranted = new IsGranted(array('attributes' => $attributes, 'subject' => $subject));
+        $request = $this->createRequest($isGranted);
+
+        // avoid the error of the subject not being found in the request attributes
+        if (null !== $subject) {
+            $request->attributes->set($subject, 'bar');
+        }
+
+        $this->setExpectedException(AccessDeniedException::class, $expectedMessage);
+
+        $listener->onKernelController($this->createFilterControllerEvent($request));
+    }
+
+    public function getAccessDeniedMessageTests()
+    {
+        yield array(array('ROLE_ADMIN'), null, 'Access Denied by controller annotation @IsGranted("ROLE_ADMIN")');
+        yield array(array('ROLE_ADMIN', 'ROLE_USER'), null, 'Access Denied by controller annotation @IsGranted(["ROLE_ADMIN", "ROLE_USER"])');
+        yield array(array('ROLE_ADMIN', 'ROLE_USER'), 'product', 'Access Denied by controller annotation @IsGranted(["ROLE_ADMIN", "ROLE_USER"], product)');
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage Not found
+     */
+    public function testNotFoundHttpException()
+    {
+        $request = $this->createRequest(new IsGranted(array('attributes' => 'ROLE_ADMIN', 'statusCode' => 404, 'message' => 'Not found')));
+        $event = $this->createFilterControllerEvent($request);
+
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        $authChecker->expects($this->any())
+            ->method('isGranted')
+            ->will($this->returnValue(false));
+
+        $listener = new IsGrantedListener($authChecker);
+        $listener->onKernelController($event);
+    }
+
+    private function createRequest(IsGranted $isGranted = null)
+    {
+        return new Request(array(), array(), array(
+            '_is_granted' => null === $isGranted ? array() : array(
+                $isGranted,
+                $isGranted,
+            ),
+        ));
+    }
+
+    private function createFilterControllerEvent(Request $request)
+    {
+        return new FilterControllerEvent($this->getMockBuilder(HttpKernelInterface::class)->getMock(), function () { return new Response(); }, $request, null);
+    }
+}


### PR DESCRIPTION
Since `isGranted()` really should be used (and is in practice) for security in 95%+ of the use-cases, it's just a little bit ugly with the `@Security` expression. This is obviously just a light simplification:

``` php
/**
 * @Route("/post/{slug}")
 *
 * BEFORE
 *
 * @Security("is_granted('ROLE_ADMIN')")
 * @Security("is_granted('EDIT', post)")
 *
 * AFTER
 *
 * @IsGranted("ROLE_ADMIN")
 * @IsGranted("EDIT", object="post")
 */
public function showAction(Post $post)
```

And yes, I'm actually creating an expression inside `@IsGranted`, which works great, but is a bit weird, and doesn't make for the best errors (e.g. if `post` were not a variable). With a bit more work, I could make `@IsGranted` work without needing to have it write an expression.
