### PR TITLE
Don't enable the security listener when security is disabled

### DIFF
--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -116,6 +116,10 @@ class SensioFrameworkExtraExtension extends Extension
         if ($config['psr_message']['enabled']) {
             $loader->load('psr7.xml');
         }
+
+        if (!$container->hasDefinition('security.token_storage')) {
+            $container->removeDefinition('sensio_framework_extra.security.listener');
+        }
     }
 
     /**


### PR DESCRIPTION
This tries to fix #427.

It worked for my application ... but I don't know which is the best way to detect in a bundle extension whether the security component/bundle is enabled or not.