### PR TITLE
cache download package archives only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
     directories:
-        - $HOME/.composer/cache
+        - $HOME/.composer/cache/files
         - .phpunit
 
 php:


### PR DESCRIPTION
Caching Packagist metadata will make the cache becoming stale too
often.