### PR TITLE
[PHP7.1] Allowing nullable types

### DIFF
--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -33,6 +33,11 @@ class ParamConverterListener implements EventSubscriberInterface
     protected $autoConvert;
 
     /**
+     * @var bool
+     */
+    private $isParameterTypeSupported;
+
+    /**
      * Constructor.
      *
      * @param ParamConverterManager $manager     A ParamConverterManager instance
@@ -42,6 +47,7 @@ class ParamConverterListener implements EventSubscriberInterface
     {
         $this->manager = $manager;
         $this->autoConvert = $autoConvert;
+        $this->isParameterTypeSupported = method_exists('ReflectionParameter', 'getType');
     }
 
     /**
@@ -96,7 +102,7 @@ class ParamConverterListener implements EventSubscriberInterface
                 $configurations[$name]->setClass($param->getClass()->getName());
             }
 
-            $configurations[$name]->setIsOptional($param->isOptional());
+            $configurations[$name]->setIsOptional($param->isOptional() || $this->isParameterTypeSupported && $param->hasType() && $param->getType()->allowsNull());
         }
 
         return $configurations;

--- a/Tests/EventListener/Fixture/FooControllerNullableParameter.php
+++ b/Tests/EventListener/Fixture/FooControllerNullableParameter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+class FooControllerNullableParameter
+{
+    public function requiredParamAction(\DateTime $param)
+    {
+    }
+
+    public function defaultParamAction(\DateTime $param = null)
+    {
+    }
+
+    public function nullableParamAction(?\DateTime $param)
+    {
+    }
+}

--- a/Tests/EventListener/ParamConverterListenerTest.php
+++ b/Tests/EventListener/ParamConverterListenerTest.php
@@ -13,6 +13,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerNullableParameter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -54,6 +55,41 @@ class ParamConverterListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FilterControllerEvent($kernel, $controllerCallable, $request, null);
 
         $listener->onKernelController($event);
+    }
+
+    /**
+     * @dataProvider settingOptionalParamProvider
+     * @requires PHP 7.1
+     */
+    public function testSettingOptionalParam($function, $isOptional)
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $request = new Request();
+
+        $converter = new ParamConverter(array('name' => 'param', 'class' => 'DateTime'));
+        $converter->setIsOptional($isOptional);
+
+        $listener = new ParamConverterListener($this->getParamConverterManager($request, array('param' => $converter)), true);
+        $event = new FilterControllerEvent(
+            $kernel,
+            array(
+                new FooControllerNullableParameter(),
+                $function,
+            ),
+            $request,
+            null
+        );
+
+        $listener->onKernelController($event);
+    }
+
+    public function settingOptionalParamProvider()
+    {
+        return array(
+            array('requiredParamAction', false),
+            array('defaultParamAction', true),
+            array('nullableParamAction', true),
+        );
     }
 
     /**

--- a/Tests/Fixtures/ActionArgumentsBundle/Controller/NullableArgumentsController.php
+++ b/Tests/Fixtures/ActionArgumentsBundle/Controller/NullableArgumentsController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Fixtures\ActionArgumentsBundle\Controller;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route("/nullable-arguments")
+ */
+class NullableArgumentsController
+{
+    /**
+     * @Route("/invoke/")
+     */
+    public function __invoke(RequestInterface $request, MessageInterface $message, ServerRequestInterface $serverRequest)
+    {
+        return new Response('<html><body>ok</body></html>');
+    }
+
+    /**
+     * @Route("/with-default")
+     */
+    public function withDefaultAction(string $d = null)
+    {
+        return new Response(null === $d ? 'yes' : 'no');
+    }
+
+    /**
+     * @Route("/without-default")
+     */
+    public function withoutDefaultAction(string $d)
+    {
+        return new Response(null === $d ? 'yes' : 'no');
+    }
+
+    /**
+     * @Route("/nullable")
+     */
+    public function nullableAction(?string $d)
+    {
+        return new Response(null === $d ? 'yes' : 'no');
+    }
+}

--- a/Tests/Functional/NullableAnnotationTest.php
+++ b/Tests/Functional/NullableAnnotationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * @requires PHP 7.1
+ */
+class NullableAnnotationTest extends WebTestCase
+{
+    public function testMissingRequiredArgumentWillResultWithError()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/nullable-arguments/without-default');
+
+        $this->assertSame(500, $client->getResponse()->getStatusCode());
+    }
+
+    public function testArgumentWithDefaultIsOptional()
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', '/nullable-arguments/with-default');
+
+        $this->assertSame('yes', $crawler->text());
+    }
+
+    public function testNullableArgumentIsOptional()
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', '/nullable-arguments/nullable');
+
+        $this->assertSame('yes', $crawler->text());
+    }
+}


### PR DESCRIPTION
Currently having function in Controller without matching entity like this is fine:
```php
    function myAction(MyEntity $e = null) // ...
```
however this one:
```php
    function myAction(?MyEntity $e) // ...
```
results in exception "MyEntity object not found by the @ParamConverter annotation."
