### PR TITLE
Adding missing use statement for controller.

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -125,6 +125,7 @@ The following annotations are defined by the bundle:
 
 This example shows all the available annotations in action::
 
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;


### PR DESCRIPTION
It didn't appear that content was omitted. As a result the code provided would not function.
I understand this example was to show all of the ExtraFramework in action. Perhaps a `// ...` Would of been better than use of the controller.