### PR TITLE
Improve ParamConverter exception messages

### DIFF
--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -47,11 +47,11 @@ class DateTimeParamConverter implements ParamConverterInterface
             $date = DateTime::createFromFormat($options['format'], $value);
 
             if (!$date) {
-                throw new NotFoundHttpException('Invalid date given.');
+                throw new NotFoundHttpException(sprintf("Invalid date given for parameter '%s'.", $param));
             }
         } else {
             if (false === strtotime($value)) {
-                throw new NotFoundHttpException('Invalid date given.');
+                throw new NotFoundHttpException(sprintf("Invalid date given for parameter '%s'.", $param));
             }
 
             $date = new DateTime($value);

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -57,7 +57,7 @@ class DoctrineParamConverter implements ParamConverterInterface
                 if ($configuration->isOptional()) {
                     $object = null;
                 } else {
-                    throw new \LogicException('Unable to guess how to get a Doctrine instance from the request information.');
+                    throw new \LogicException(sprintf("Unable to guess how to get a Doctrine instance from the request information for parameter '%s'.", $name));
                 }
             }
         }

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -51,7 +51,7 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(), array(), array('start' => 'Invalid DateTime Format'));
         $config = $this->createConfiguration('DateTime', 'start');
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given.');
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', "Invalid date given for parameter 'start'.");
         $this->converter->apply($request, $config);
     }
 
@@ -61,7 +61,7 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
         $config = $this->createConfiguration('DateTime', 'start');
         $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'd.m.Y')));
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given.');
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', "Invalid date given for parameter 'start'.");
         $this->converter->apply($request, $config);
     }
 


### PR DESCRIPTION
Add the name of the faulty parameter to the exception message.