### PR TITLE
[Template] Added a way to auto search template in app/ directory

### DIFF
--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -47,6 +47,8 @@ class Template extends ConfigurationAnnotation
      */
     private $owner;
 
+    private $inApp;
+
     /**
      * Returns the array of templates variables.
      *
@@ -153,5 +155,15 @@ class Template extends ConfigurationAnnotation
     public function getOwner()
     {
         return $this->owner;
+    }
+
+    public function getInApp()
+    {
+        return $this->inApp;
+    }
+
+    public function setInApp($inApp)
+    {
+        $this->inApp = $inApp;
     }
 }

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -62,7 +62,7 @@ class TemplateListener implements EventSubscriberInterface
 
         // when no template has been given, try to resolve it based on the controller
         if (null === $template->getTemplate()) {
-            $template->setTemplate($this->templateGuesser->guessTemplateName($controller, $request));
+            $template->setTemplate($this->templateGuesser->guessTemplateName($controller, $request, $template->getInApp()));
         }
     }
 

--- a/Templating/TemplateGuesser.php
+++ b/Templating/TemplateGuesser.php
@@ -54,7 +54,7 @@ class TemplateGuesser
      *
      * @throws \InvalidArgumentException
      */
-    public function guessTemplateName($controller, Request $request)
+    public function guessTemplateName($controller, Request $request, $inApp = false)
     {
         if (is_object($controller) && method_exists($controller, '__invoke')) {
             $controller = array($controller, '__invoke');
@@ -83,7 +83,8 @@ class TemplateGuesser
         }
 
         $bundleName = null;
-        if ($bundle = $this->getBundleForClass($className)) {
+
+        if (!$inApp && $bundle = $this->getBundleForClass($className)) {
             while ($bundleName = $bundle->getName()) {
                 if (null === $parentBundleName = $bundle->getParent()) {
                     $bundleName = $bundle->getName();


### PR DESCRIPTION
Symfony best practices state we should use the `app/` folder to store our templates.
So now the `@Template` annotation is not so useful any-more. Let's make it great again ;)

Example in the SE:
```diff
diff --git a/app/Resources/views/default/index.html.twig b/app/Resources/views/Default/index.html.twig
similarity index 100%
rename from app/Resources/views/default/index.html.twig
rename to app/Resources/views/Default/index.html.twig
diff --git a/src/AppBundle/Controller/DefaultController.php b/src/AppBundle/Controller/DefaultController.php
index 5216afe..d984d19 100644
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -10,12 +11,13 @@ class DefaultController extends Controller
 {
     /**
      * @Route("/", name="homepage")
+     * @Template(inApp=true)
      */
     public function indexAction(Request $request)
     {
         // replace this example code with whatever you need
-        return $this->render('default/index.html.twig', [
+        return [
             'base_dir' => realpath($this->getParameter('kernel.root_dir').'/..').DIRECTORY_SEPARATOR,
-        ]);
+        ];
     }
 }
```

ping @javiereguiluz