### PR TITLE
Register tagged security expression language providers

### DIFF
--- a/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddExpressionLanguageProvidersPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->has('sensio_framework_extra.security.expression_language.default')) {
+            $definition = $container->findDefinition('sensio_framework_extra.security.expression_language.default');
+            foreach ($container->findTaggedServiceIds('security.expression_language_provider') as $id => $attributes) {
+                $definition->addMethodCall('registerProvider', array(new Reference($id)));
+            }
+        }
+    }
+}

--- a/SensioFrameworkExtraBundle.php
+++ b/SensioFrameworkExtraBundle.php
@@ -4,6 +4,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
 use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\AddParamConverterPass;
 use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\LegacyPass;
 
@@ -29,5 +30,6 @@ class SensioFrameworkExtraBundle extends Bundle
 
         $container->addCompilerPass(new AddParamConverterPass());
         $container->addCompilerPass(new LegacyPass());
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
     }
 }

--- a/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\DependencyInjection;
+
+use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddExpressionLanguageProvidersPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AddExpressionLanguageProvidersPass
+     */
+    private $pass;
+
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var Definition
+     */
+    private $expressionLangDefinition;
+
+    public function setUp()
+    {
+        $this->pass = new AddExpressionLanguageProvidersPass();
+        $this->container = new ContainerBuilder();
+        $this->expressionLangDefinition = new Definition();
+        $this->container->setDefinition('sensio_framework_extra.security.expression_language.default', $this->expressionLangDefinition);
+    }
+
+    public function testProcessNoOpNoExpressionLang()
+    {
+        $this->container->removeDefinition('sensio_framework_extra.security.expression_language.default');
+        $this->pass->process($this->container);
+    }
+
+    public function testProcessNoOpNoTaggedServices()
+    {
+        $this->pass->process($this->container);
+        $this->assertCount(0, $this->expressionLangDefinition->getMethodCalls());
+    }
+
+    public function testProcessAddsTaggedServices()
+    {
+        $provider = new Definition();
+        $provider->setTags(array(
+            'security.expression_language_provider' => array(
+                array(),
+            ),
+        ));
+
+        $this->container->setDefinition('provider', $provider);
+
+        $this->pass->process($this->container);
+
+        $methodCalls = $this->expressionLangDefinition->getMethodCalls();
+        $this->assertCount(1, $methodCalls);
+        $this->assertEquals(array('registerProvider', array(new Reference('provider'))), $methodCalls[0]);
+    }
+}

--- a/Tests/DependencyInjection/Compiler/AddParamConverterPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddParamConverterPassTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\DependencyInjection;
+
+use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\AddParamConverterPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddParamConverterPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AddParamConverterPass
+     */
+    private $pass;
+
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var Definition
+     */
+    private $managerDefinition;
+
+    public function setUp()
+    {
+        $this->pass = new AddParamConverterPass();
+        $this->container = new ContainerBuilder();
+        $this->managerDefinition = new Definition();
+        $this->container->setDefinition('sensio_framework_extra.converter.manager', $this->managerDefinition);
+    }
+
+    public function testProcessNoOpNoManager()
+    {
+        $this->container->removeDefinition('sensio_framework_extra.converter.manager');
+        $this->pass->process($this->container);
+    }
+
+    public function testProcessNoOpNoTaggedServices()
+    {
+        $this->pass->process($this->container);
+        $this->assertCount(0, $this->managerDefinition->getMethodCalls());
+    }
+
+    public function testProcessAddsTaggedServices()
+    {
+        $paramConverter1 = new Definition();
+        $paramConverter1->setTags(array(
+            'request.param_converter' => array(
+                array(
+                    'priority' => 'false',
+                ),
+            ),
+        ));
+
+        $paramConverter2 = new Definition();
+        $paramConverter2->setTags(array(
+            'request.param_converter' => array(
+                array(
+                    'converter' => 'foo',
+                ),
+            ),
+        ));
+
+        $paramConverter3 = new Definition();
+        $paramConverter3->setTags(array(
+            'request.param_converter' => array(
+                array(
+                    'priority' => 5,
+                ),
+            ),
+        ));
+
+        $this->container->setDefinition('param_converter_one', $paramConverter1);
+        $this->container->setDefinition('param_converter_two', $paramConverter2);
+        $this->container->setDefinition('param_converter_three', $paramConverter3);
+
+        $this->pass->process($this->container);
+
+        $methodCalls = $this->managerDefinition->getMethodCalls();
+        $this->assertCount(3, $methodCalls);
+        $this->assertEquals(array('add', array(new Reference('param_converter_one'), 0, null)), $methodCalls[0]);
+        $this->assertEquals(array('add', array(new Reference('param_converter_two'), 0, 'foo')), $methodCalls[1]);
+        $this->assertEquals(array('add', array(new Reference('param_converter_three'), 5, null)), $methodCalls[2]);
+    }
+}


### PR DESCRIPTION
Custom security expression language providers are currently not registered which leads to issue https://github.com/symfony/symfony/issues/21305.