### PR TITLE
Fix default vars resolution for Template annotation

### DIFF
--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -143,14 +143,18 @@ class TemplateListener implements EventSubscriberInterface
 
             $arguments = array();
             foreach ($r->getMethod($action)->getParameters() as $param) {
-                $arguments[] = $param->getName();
+                $arguments[] = $param;
             }
         }
 
         // fetch the arguments of @Template.vars or everything if desired
         // and assign them to the designated template
         foreach ($arguments as $argument) {
-            $parameters[$argument] = $request->attributes->get($argument);
+            if ($argument instanceof \ReflectionParameter) {
+                $parameters[$name = $argument->getName()] = !$request->attributes->has($name) && $argument->isDefaultValueAvailable() ? $argument->getDefaultValue() : $request->attributes->get($name);
+            } else {
+                $parameters[$argument] = $request->attributes->get($argument);
+            }
         }
 
         return $parameters;


### PR DESCRIPTION
Fixes broken `@Template` default vars resolution which was relying on a buggy behavior fixed https://github.com/symfony/symfony/pull/21379 (the annotation class loader no longer sets request attributes for any argument that has a default value, but only for ones which may be expected in the route path).