### PR TITLE
Do not throw exception when _template is not an @Template

### DIFF
--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -62,7 +62,7 @@ class TemplateListener implements EventSubscriberInterface
 
         // we need the @Template annotation object or we cannot continue
         if (!$template instanceof Template) {
-            throw new \InvalidArgumentException('Request attribute "_template" is reserved for @Template annotations.');
+            return;
         }
 
         $template->setOwner($controller = $event->getController());


### PR DESCRIPTION
Currently, when the `_template` request attribute is set, this listener will throw an exception. I don't see why it should throw an exception, returning is enough to not continue.

This will allow other bundles to work with `_template`. For instance, the CmfRoutingBundle uses the `_template` attribute for it's `template_by_type` configuration (which renders a template based on content type). We currently have to do some black magic to rename `_template` to i.e. `contentTemplate` in order to avoid getting this exception.