### PR TITLE
Controller arguments with default values should be default optional

### DIFF
--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -86,23 +86,27 @@ class ParamConverterListener implements EventSubscriberInterface
     private function autoConfigure(\ReflectionFunctionAbstract $r, Request $request, $configurations)
     {
         foreach ($r->getParameters() as $param) {
-            if (!$param->getClass() || $param->getClass()->isInstance($request)) {
+            if ($param->getClass() && $param->getClass()->isInstance($request)) {
                 continue;
             }
 
             $name = $param->getName();
 
-            if (!isset($configurations[$name])) {
-                $configuration = new ParamConverter(array());
-                $configuration->setName($name);
-                $configuration->setClass($param->getClass()->getName());
+            if ($param->getClass()) {
+                if (!isset($configurations[$name])) {
+                    $configuration = new ParamConverter(array());
+                    $configuration->setName($name);
+                    $configuration->setClass($param->getClass()->getName());
 
-                $configurations[$name] = $configuration;
-            } elseif (null === $configurations[$name]->getClass()) {
-                $configurations[$name]->setClass($param->getClass()->getName());
+                    $configurations[$name] = $configuration;
+                } elseif (null === $configurations[$name]->getClass()) {
+                    $configurations[$name]->setClass($param->getClass()->getName());
+                }
             }
 
-            $configurations[$name]->setIsOptional($param->isOptional() || $this->isParameterTypeSupported && $param->hasType() && $param->getType()->allowsNull());
+            if (isset($configurations[$name])) {
+                $configurations[$name]->setIsOptional($param->isOptional() || $param->isDefaultValueAvailable() || $this->isParameterTypeSupported && $param->hasType() && $param->getType()->allowsNull());
+            }
         }
 
         return $configurations;

--- a/Tests/Fixtures/FooBundle/Controller/OptionalArgumentsController.php
+++ b/Tests/Fixtures/FooBundle/Controller/OptionalArgumentsController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route("/optional-arguments")
+ */
+class OptionalArgumentsController
+{
+    /**
+     * @Route("/with-default-followed-by-mandatory", defaults={"e" = null})
+     * @ParamConverter(name="d", class="Tests\Fixtures\FooBundle\Entity\Foo")
+     */
+    public function withDefaultFollowedByMandatory($d = null, $e)
+    {
+        return new Response(null === $d ? 'yes' : 'no');
+    }
+}

--- a/Tests/Fixtures/FooBundle/Entity/Foo.php
+++ b/Tests/Fixtures/FooBundle/Entity/Foo.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\FooBundle\Entity;
+
+use Doctrine\ORM\Mapping;
+
+/**
+ * @Mapping\Entity
+ */
+class Foo
+{
+    /**
+     * @Mapping\Column(type="integer")
+     * @Mapping\Id
+     * @Mapping\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+}

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -22,6 +22,7 @@ class TestKernel extends Kernel
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Tests\Fixtures\FooBundle\FooBundle(),
         );
     }

--- a/Tests/Fixtures/config/config.yml
+++ b/Tests/Fixtures/config/config.yml
@@ -5,6 +5,13 @@ framework:
         engine: [twig, php]
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
+doctrine:
+    dbal:
+        driver:   pdo_sqlite
+        path:     "%kernel.root_dir%/data/db.sqlite"
+
+    orm:
+        auto_mapping: true
 
 services:
     test.invokable.predefined:

--- a/Tests/Functional/OptionalArgumentsTest.php
+++ b/Tests/Functional/OptionalArgumentsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class OptionalArgumentsTest extends WebTestCase
+{
+    public function testArgumentWithDefaultFollowedByMandatoryIsOptional()
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', '/optional-arguments/with-default-followed-by-mandatory');
+
+        $this->assertSame('yes', $crawler->text());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,16 @@
         "symfony/security-bundle": "~2.4|~3.0",
         "symfony/yaml": "~2.3|~3.0",
         "symfony/twig-bundle": "~2.3|~3.0",
-        "twig/twig": "~1.11|~2.0",
+        "twig/twig": "~1.12|~2.0",
         "symfony/asset": "~2.7|~3.0",
         "symfony/browser-kit": "~2.3|~3.0",
         "symfony/phpunit-bridge": "~3.2",
         "symfony/dom-crawler": "~2.3|~3.0",
         "symfony/templating": "~2.3|~3.0",
         "symfony/translation": "~2.3|~3.0",
-        "zendframework/zend-diactoros": "^1.3"
+        "zendframework/zend-diactoros": "^1.3",
+        "doctrine/doctrine-bundle": "~1.5",
+        "doctrine/orm": "~2.4,>=2.4.5"
     },
     "suggest": {
         "symfony/psr-http-message-bridge": "To use the PSR-7 converters",


### PR DESCRIPTION
This makes that for e.g:

```php
function fooAction($foo = null, Request $request);
```

the `$foo` parameter is considered optional.

Before it was relying on `ReflectionParameter::isOptional()` only, which returns false if the parameter is not the last. This additionally checks for `isDefaultValueAvailable()`. 
To me it's a bug that was hidden by the fact request attributes were automatically created for any parameter with a default value, that has been fixed in symfony.

Fixes https://github.com/symfony/symfony/issues/21563.