### PR TITLE
Fix param converter support for nullable scalar/array types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
 
 matrix:
     include:

--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -91,21 +91,24 @@ class ParamConverterListener implements EventSubscriberInterface
             }
 
             $name = $param->getName();
+            $class = $param->getClass();
+            $hasType = $this->isParameterTypeSupported && $param->hasType();
 
-            if ($param->getClass()) {
+            if ($class || $hasType) {
                 if (!isset($configurations[$name])) {
                     $configuration = new ParamConverter(array());
                     $configuration->setName($name);
-                    $configuration->setClass($param->getClass()->getName());
 
                     $configurations[$name] = $configuration;
-                } elseif (null === $configurations[$name]->getClass()) {
-                    $configurations[$name]->setClass($param->getClass()->getName());
+                }
+
+                if ($class && null === $configurations[$name]->getClass()) {
+                    $configurations[$name]->setClass($class->getName());
                 }
             }
 
             if (isset($configurations[$name])) {
-                $configurations[$name]->setIsOptional($param->isOptional() || $param->isDefaultValueAvailable() || $this->isParameterTypeSupported && $param->hasType() && $param->getType()->allowsNull());
+                $configurations[$name]->setIsOptional($param->isOptional() || $param->isDefaultValueAvailable() || $hasType && $param->getType()->allowsNull());
             }
         }
 

--- a/Tests/Fixtures/ActionArgumentsBundle/ActionArgumentsBundle.php
+++ b/Tests/Fixtures/ActionArgumentsBundle/ActionArgumentsBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Fixtures\ActionArgumentsBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ActionArgumentsBundle extends Bundle
+{
+}

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -24,12 +24,17 @@ class TestKernel extends Kernel
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Tests\Fixtures\FooBundle\FooBundle(),
+            new Tests\Fixtures\ActionArgumentsBundle\ActionArgumentsBundle(),
         );
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(__DIR__.'/config/config.yml');
+
+        if (PHP_VERSION_ID >= 70100) {
+            $loader->load(__DIR__.'/config/nullable_type/config.yml');
+        }
     }
 
     public function getCacheDir()

--- a/Tests/Fixtures/config/nullable_type/config.yml
+++ b/Tests/Fixtures/config/nullable_type/config.yml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        resource: '%kernel.root_dir%/config/nullable_type/routing.yml'

--- a/Tests/Fixtures/config/nullable_type/routing.yml
+++ b/Tests/Fixtures/config/nullable_type/routing.yml
@@ -1,0 +1,7 @@
+foo_bundle:
+    resource: "@FooBundle/Controller"
+    type: annotation
+
+action_arguments_bundle:
+    resource: "@ActionArgumentsBundle/Controller"
+    type: annotation


### PR DESCRIPTION
Tests were always broken on my local. That was due to a unregistered bundle (fixture) used by the `NullableAnnotationTest` which requires PHP 7.1, and 7.1 is not enabled on travis.

Enabling the bundle revealed that the test is failing. It expects the following to return `"yes"`:

```php
/**
 * @Route("/nullable")
 */
public function nullableAction(?string $d)
{
    return new Response(null === $d ? 'yes' : 'no');
}
```

But it was throwing instead:

> Controller "NullableArgumentsController" requires that you provide a value for the "$d" argument (because there is no default value or because there is a non optional argument after this one).

Because autoconfiguration is actually skipped if the param doesn't have a class.
This fixes it, enabling 7.1 on travis.