### PR TITLE
Default FQCN for invokable controllers

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -40,6 +40,8 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         $classAnnot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass);
         if ($classAnnot instanceof FrameworkExtraBundleRoute && $service = $classAnnot->getService()) {
             $route->setDefault('_controller', $service.':'.$method->getName());
+        } else if ('__invoke' === $method->getName()) {
+            $route->setDefault('_controller', $class->getName());
         } else {
             $route->setDefault('_controller', $class->getName().'::'.$method->getName());
         }

--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -40,7 +40,7 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         $classAnnot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass);
         if ($classAnnot instanceof FrameworkExtraBundleRoute && $service = $classAnnot->getService()) {
             $route->setDefault('_controller', $service.':'.$method->getName());
-        } else if ('__invoke' === $method->getName()) {
+        } elseif ('__invoke' === $method->getName()) {
             $route->setDefault('_controller', $class->getName());
         } else {
             $route->setDefault('_controller', $class->getName().'::'.$method->getName());
@@ -79,7 +79,7 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
         $routeName = parent::getDefaultRouteName($class, $method);
 
         return preg_replace(
-            array('/(bundle|controller)_/','/action(_\d+)?$/', '/__/'),
+            array('/(bundle|controller)_/', '/action(_\d+)?$/', '/__/'),
             array('_', '\\1', '_'),
             $routeName
         );

--- a/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -124,4 +124,20 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('new'));
         $this->assertEquals(array('POST'), $rc->get('new')->getMethods());
     }
+
+    public function testInvokableControllerLoad()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\InvokableController');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
+        $this->assertCount(1, $rc);
+
+        $route = $rc->get('index');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
+        $this->assertSame(array('_controller' => 'Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\InvokableController'), $route->getDefaults());
+    }
 }

--- a/Tests/Routing/Fixtures/InvokableController.php
+++ b/Tests/Routing/Fixtures/InvokableController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class InvokableController
+{
+    /**
+     * @Route("/", name="index")
+     */
+    public function __invoke()
+    {
+    }
+}


### PR DESCRIPTION
This PR implements the [@dunglas's idea](https://github.com/symfony/symfony/pull/21723#issuecomment-282273577) to make the `service` argument optional for invokable controllers, it allows to omit this argument when using the new convention of using FQN as id.

 **Before:**
```
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;

/**
 * @Route(service="AppBundle\Controller\Hello")
 */
class Hello
{
    private $logger;

    public function __construct(LoggerInterface $logger)
    {
        $this->logger = $logger;
    }

    /**
     * @Route("/hello/{name}", name="hello")
     */
    public function __invoke($name = 'World')
    {
        $this->logger->info('log entry...');

        return new Response(sprintf('Hello %s!', $name));
    }
}
```

**After:**
```
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;

class Hello
{
    private $logger;

    public function __construct(LoggerInterface $logger)
    {
        $this->logger = $logger;
    }

    /**
     * @Route("/hello/{name}", name="hello")
     */
    public function __invoke($name = 'World')
    {
        $this->logger->info('log entry...');

        return new Response(sprintf('Hello %s!', $name));
    }
}
```
**TODO**
- [x] Add Tests
- [x] Fix fabbot.io