### PR TITLE
Rename property to isOptional to correct autocomplete in annotations plugin

### DIFF
--- a/Configuration/ParamConverter.php
+++ b/Configuration/ParamConverter.php
@@ -45,7 +45,7 @@ class ParamConverter extends ConfigurationAnnotation
      *
      * @var bool
      */
-    private $optional = false;
+    private $isOptional = false;
 
     /**
      * Use explicitly named converter instead of iterating by priorities.
@@ -131,7 +131,7 @@ class ParamConverter extends ConfigurationAnnotation
      */
     public function setIsOptional($optional)
     {
-        $this->optional = (bool) $optional;
+        $this->isOptional = (bool) $optional;
     }
 
     /**
@@ -141,7 +141,7 @@ class ParamConverter extends ConfigurationAnnotation
      */
     public function isOptional()
     {
-        return $this->optional;
+        return $this->isOptional;
     }
 
     /**


### PR DESCRIPTION
IDE suggests annotation fields depends on class properties, so it suggests `optional`. But correct name is `isOptional` because there is setter `setIsOptional`