### PR TITLE
Remove useless call

### DIFF
--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -142,8 +142,6 @@ class HttpCacheListener implements EventSubscriberInterface
 
             unset($this->etags[$request]);
         }
-
-        $event->setResponse($response);
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
`$response` is object passed by reference, it can be modified and not requires to be setted again