### PR TITLE
Check that controller is an array before setting it to Template

### DIFF
--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -59,7 +59,10 @@ class TemplateListener implements EventSubscriberInterface
             return;
         }
 
-        $template->setOwner($controller = $event->getController());
+        $controller = $event->getController();
+        if (is_array($controller)) {
+            $template->setOwner($controller);
+        }
 
         // when no template has been given, try to resolve it based on the controller
         if (null === $template->getTemplate()) {

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -88,12 +88,16 @@ class TemplateListener implements EventSubscriberInterface
         }
 
         $parameters = $event->getControllerResult();
-        $owner = $template->getOwner();
-        list($controller, $action) = $owner;
 
         // when the annotation declares no default vars and the action returns
         // null, all action method arguments are used as default vars
         if (null === $parameters) {
+            $owner = $template->getOwner();
+            $controller = null;
+            $action = null;
+            if ($owner && count($owner) >= 2) {
+                list($controller, $action) = $owner;
+            }
             $parameters = $this->resolveDefaultParameters($request, $template, $controller, $action);
         }
 
@@ -135,7 +139,7 @@ class TemplateListener implements EventSubscriberInterface
         $parameters = array();
         $arguments = $template->getVars();
 
-        if (0 === count($arguments)) {
+        if (0 === count($arguments) && $controller && $action) {
             $r = new \ReflectionObject($controller);
 
             $arguments = array();

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -152,7 +152,8 @@ class TemplateListener implements EventSubscriberInterface
         // and assign them to the designated template
         foreach ($arguments as $argument) {
             if ($argument instanceof \ReflectionParameter) {
-                $parameters[$name = $argument->getName()] = !$request->attributes->has($name) && $argument->isDefaultValueAvailable() ? $argument->getDefaultValue() : $request->attributes->get($name);
+                $name = $argument->getName();
+                $parameters[$name] = !$request->attributes->has($name) && $argument->isDefaultValueAvailable() ? $argument->getDefaultValue() : $request->attributes->get($name);
             } else {
                 $parameters[$argument] = $request->attributes->get($argument);
             }

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -95,7 +95,7 @@ class TemplateListener implements EventSubscriberInterface
             $owner = $template->getOwner();
             $controller = null;
             $action = null;
-            if ($owner && count($owner) >= 2) {
+            if (is_array($owner) && is_callable($owner)) {
                 list($controller, $action) = $owner;
             }
             $parameters = $this->resolveDefaultParameters($request, $template, $controller, $action);

--- a/Tests/EventListener/TemplateListenerTest.php
+++ b/Tests/EventListener/TemplateListenerTest.php
@@ -39,7 +39,7 @@ class TemplateListenerTest extends \PHPUnit_Framework_TestCase
                   ->with('sensio_framework_extra.view.guesser')
                   ->willReturn($guesser);
         $listener = new TemplateListener($container);
-        $controller = function (){};
+        $controller = function () {};
         $request = $this->getRequestWithTemplate();
         $event = new FilterControllerEvent($this->getKernelMock(), $controller, $request, HttpKernelInterface::MASTER_REQUEST);
         $listener->onKernelController($event);

--- a/Tests/EventListener/TemplateListenerTest.php
+++ b/Tests/EventListener/TemplateListenerTest.php
@@ -66,6 +66,7 @@ class TemplateListenerTest extends \PHPUnit_Framework_TestCase
         $template = new Template(array());
         $request = new Request();
         $request->attributes->set('_template', $template);
+
         return $request;
     }
 }

--- a/Tests/EventListener/TemplateListenerTest.php
+++ b/Tests/EventListener/TemplateListenerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\EventListener;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class TemplateListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOnKernelViewCanNotFindOwner()
+    {
+        $templating = $this->getTemplatingMock();
+        $templating->expects($this->once())
+            ->method('renderResponse')
+            ->willReturn(new Response('bar'));
+        $container = $this->getContainerMock();
+        $container->expects($this->any())
+            ->method('get')
+            ->with('templating')
+            ->willReturn($templating);
+        $response = new Response('foo');
+        $event = new GetResponseForControllerResultEvent($this->getKernelMock(), $this->getRequestWithTemplate(), HttpKernelInterface::MASTER_REQUEST, $response);
+        $event->setControllerResult(null);
+        $listener = new TemplateListener($container);
+        $listener->onKernelView($event);
+    }
+
+    public function testOnKernelControllerWithClosureController()
+    {
+        $guesser = $this->getMockBuilder('\Sensio\Bundle\FrameworkExtraBundle\Templating\TemplateGuesser')->disableOriginalConstructor()->getMock();
+        $container = $this->getContainerMock();
+        $container->expects($this->any())
+                  ->method('get')
+                  ->with('sensio_framework_extra.view.guesser')
+                  ->willReturn($guesser);
+        $listener = new TemplateListener($container);
+        $controller = function (){};
+        $request = $this->getRequestWithTemplate();
+        $event = new FilterControllerEvent($this->getKernelMock(), $controller, $request, HttpKernelInterface::MASTER_REQUEST);
+        $listener->onKernelController($event);
+        $this->assertNull($request->attributes->get('_template')->getTemplate());
+    }
+
+    private function getContainerMock()
+    {
+        return $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+    }
+
+    private function getKernelMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
+    }
+
+    private function getTemplatingMock()
+    {
+        return $this->getMockBuilder('\Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')->getMock();
+    }
+
+    private function getRequestWithTemplate()
+    {
+        $template = new Template(array());
+        $request = new Request();
+        $request->attributes->set('_template', $template);
+        return $request;
+    }
+}


### PR DESCRIPTION
Controller returned by FilterControllerEvent is of type callable and not necessary an array.
It can happen that another bundle change this controller and put instead a closure.
We need to check if we can really set this controller to the Template.

It is linked to this issue: https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/421