### PR TITLE
add option "strict" for date creation with DateTime::createFromFormat()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * bumped Symfony minimum version to 3.0
  * bumped PHP minimum version to 5.5.9
  * removed class parameters in container definitions
+ * [BC break] DateTimeParamConverter strictly validates the input date when using with 'format' option
 
 3.0
 ---

--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -48,6 +48,13 @@ class DateTimeParamConverter implements ParamConverterInterface
         if (isset($options['format'])) {
             $date = $class::createFromFormat($options['format'], $value);
 
+            if (isset($options['strict']) && true === $options['strict']) {
+                $errors = DateTime::getLastErrors();
+                if (0 < $errors['warning_count']) {
+                    $date = false;
+                }
+            }
+
             if (!$date) {
                 throw new NotFoundHttpException(sprintf('Invalid date given for parameter "%s".', $param));
             }

--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -48,7 +48,7 @@ class DateTimeParamConverter implements ParamConverterInterface
         if (isset($options['format'])) {
             $date = $class::createFromFormat($options['format'], $value);
 
-            if (isset($options['strict']) && true === $options['strict'] && 0 < DateTime::getLastErrors()['warning_count']) {
+            if (0 < DateTime::getLastErrors()['warning_count']) {
                 $date = false;
             }
 

--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -48,11 +48,8 @@ class DateTimeParamConverter implements ParamConverterInterface
         if (isset($options['format'])) {
             $date = $class::createFromFormat($options['format'], $value);
 
-            if (isset($options['strict']) && true === $options['strict']) {
-                $errors = DateTime::getLastErrors();
-                if (0 < $errors['warning_count']) {
-                    $date = false;
-                }
+            if (isset($options['strict']) && true === $options['strict'] && 0 < DateTime::getLastErrors()['warning_count']) {
+                $date = false;
             }
 
             if (!$date) {

--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -244,6 +244,18 @@ is accepted. You can be stricter with input given through the options::
     {
     }
 
+When using ``format`` option, you can use the ``strict`` option in order to
+validate strictly the input. Without this option activated, ``2017-21-22`` will
+be converted to ``2018-09-22``::
+
+    /**
+     * @Route("/blog/archive/{date}")
+     * @ParamConverter("date", options={"format": "Y-m-d", "strict": true})
+     */
+    public function archiveAction(\DateTime $date)
+    {
+    }
+
 Creating a Converter
 --------------------
 

--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -244,17 +244,7 @@ is accepted. You can be stricter with input given through the options::
     {
     }
 
-When using ``format`` option, you can use the ``strict`` option in order to
-validate strictly the input. Without this option activated, ``2017-21-22`` will
-be converted to ``2018-09-22``::
-
-    /**
-     * @Route("/blog/archive/{date}")
-     * @ParamConverter("date", options={"format": "Y-m-d", "strict": true})
-     */
-    public function archiveAction(\DateTime $date)
-    {
-    }
+A date in a wrong format like ``2017-21-22`` will throw Exception.
 
 Creating a Converter
 --------------------

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -72,10 +72,12 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request(array(), array(), array('start' => '2012-21-07'));
         $config = $this->createConfiguration('DateTime', 'start');
-        $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'Y-m-d', 'strict' => true)));
+        $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'Y-m-d')));
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
         $this->converter->apply($request, $config);
+
+        $this->assertInstanceOf('DateTime', $request->attributes->get('start'));
+        $this->assertEquals('2013-09-07', $request->attributes->get('start')->format('Y-m-d'));
     }
 
     public function testApplyWithYmdFormatAndStrictInvalidDate404Exception()

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -68,6 +68,26 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->converter->apply($request, $config);
     }
 
+    public function testApplyWithYmdFormatAndNonStrict()
+    {
+        $request = new Request(array(), array(), array('start' => '2012-21-07'));
+        $config = $this->createConfiguration('DateTime', 'start');
+        $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'Y-m-d', 'strict' => true)));
+
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
+        $this->converter->apply($request, $config);
+    }
+
+    public function testApplyWithYmdFormatAndStrictInvalidDate404Exception()
+    {
+        $request = new Request(array(), array(), array('start' => '2012-21-07'));
+        $config = $this->createConfiguration('DateTime', 'start');
+        $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'Y-m-d', 'strict' => true)));
+
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
+        $this->converter->apply($request, $config);
+    }
+
     public function testApplyOptionalWithEmptyAttribute()
     {
         $request = new Request(array(), array(), array('start' => null));

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -68,23 +68,11 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->converter->apply($request, $config);
     }
 
-    public function testApplyWithYmdFormatAndNonStrict()
+    public function testApplyWithYmdFormatInvalidDate404Exception()
     {
         $request = new Request(array(), array(), array('start' => '2012-21-07'));
         $config = $this->createConfiguration('DateTime', 'start');
         $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'Y-m-d')));
-
-        $this->converter->apply($request, $config);
-
-        $this->assertInstanceOf('DateTime', $request->attributes->get('start'));
-        $this->assertEquals('2013-09-07', $request->attributes->get('start')->format('Y-m-d'));
-    }
-
-    public function testApplyWithYmdFormatAndStrictInvalidDate404Exception()
-    {
-        $request = new Request(array(), array(), array('start' => '2012-21-07'));
-        $config = $this->createConfiguration('DateTime', 'start');
-        $config->expects($this->any())->method('getOptions')->will($this->returnValue(array('format' => 'Y-m-d', 'strict' => true)));
 
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
         $this->converter->apply($request, $config);


### PR DESCRIPTION
When using format="Y-m-d", the string like "2017-22-05" creates a DateTime of "2018-10-05" with warning.

This case should be considered invalid, for that, an option "strict" is added. When activated, if DateTime::createFromFormat() emits warnings, we will throw Exception too