### PR TITLE
Fix DoctrineParamConverter (don't call ->find() if it's not the primary key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.0
 ---
 
+ * fixed ParamConverter behaviour to call ->find() only with primary keys
  * renamed setETag to setEtag for consistency with Symfony core (use Etag in @Cache now instead of ETag)
  * added must-revalidate support for @Cache annotation
  * Response cache headers set in controllers now take precedence over the ones defined with the @Cache annotation

--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -107,6 +107,12 @@ class DoctrineParamConverter implements ParamConverterInterface
             $method = $options['repository_method'];
         } else {
             $method = 'find';
+            $em = $this->getManager($options['entity_manager'], $class);
+            $metadata = $em->getClassMetadata($class);
+
+            if (count($metadata->getIdentifier()) > 1 || !$metadata->isIdentifier($name)) {
+                return false;
+            }
         }
 
         try {
@@ -180,7 +186,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
 
         if ($options['strip_null']) {
-            $criteria = array_filter($criteria, function ($value) { return !is_null($value); });
+            $criteria = array_filter($criteria, function ($value) { return null !== $value; });
         }
 
         if (!$criteria) {


### PR DESCRIPTION
Fixes #400 
