### PR TITLE
Follow Symfony defaults for routes without name

### DIFF
--- a/Routing/AnnotatedRouteControllerLoader.php
+++ b/Routing/AnnotatedRouteControllerLoader.php
@@ -80,11 +80,12 @@ class AnnotatedRouteControllerLoader extends AnnotationClassLoader
      */
     protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
     {
-        $routeName = parent::getDefaultRouteName($class, $method);
+        $classMethodParsed = preg_replace('/([a-z])([A-Z])/', '$1_$2', $class->name.'_'.$method->name);
+        $routeName = strtolower(str_replace('\\', '_', $classMethodParsed));
 
         return preg_replace(array(
             '/(bundle|controller)_/',
-            '/action(_\d+)?$/',
+            '/_action(_\d+)?$/',
             '/__/',
         ), array(
             '_',

--- a/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/Tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -127,7 +127,7 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
         $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\FoobarController');
 
         $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
-        $this->assertCount(2, $rc);
+        $this->assertCount(3, $rc);
 
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('index'));
         // depending on the Symfony version, it can return GET or an empty array (on 2.3)
@@ -137,5 +137,10 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $rc->get('new'));
         $this->assertEquals(array('POST'), $rc->get('new')->getMethods());
+
+        $noNameRoute = $rc->get('sensio_framework_extra_tests_routing_fixtures_foobar_no_name');
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $noNameRoute);
+        $methods = $noNameRoute->getMethods();
+        $this->assertTrue(empty($methods) || array('GET') == $methods);
     }
 }

--- a/Tests/Routing/Fixtures/FoobarController.php
+++ b/Tests/Routing/Fixtures/FoobarController.php
@@ -25,4 +25,11 @@ class FoobarController
     public function newAction()
     {
     }
+
+    /**
+     * @Route("/")
+     */
+    public function noNameAction()
+    {
+    }
 }


### PR DESCRIPTION
minor #218 Default route name conversion does not follow Symfony defaults
This PR was squashed before being merged into the 3.0 branch (closes #218).

Discussion
----------
When a route is defined without name, the default one should follow the Symfony convention
My\TinyCmsBundle -> my_tiny_cms

Commits
-------
[5fef8e4 Follow Symfony defaults for routes without name](https://github.com/sensiolabs/SensioFrameworkExtraBundle/commit/5fef8e4f150f53dd01ffcc9cba137c2eba4910f2)