### PR TITLE
Allow custom exception message for @Security annotation

### DIFF
--- a/Configuration/Security.php
+++ b/Configuration/Security.php
@@ -20,6 +20,17 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
 class Security extends ConfigurationAnnotation
 {
     protected $expression;
+    protected $message;
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
 
     public function getExpression()
     {

--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -65,7 +65,7 @@ class SecurityListener implements EventSubscriberInterface
         }
 
         if (!$this->language->evaluate($configuration->getExpression(), $this->getVariables($request))) {
-            throw new AccessDeniedException(sprintf('Expression "%s" denied access.', $configuration->getExpression()));
+            throw new AccessDeniedException($configuration->getMessage() ?: sprintf('Expression "%s" denied access.', $configuration->getExpression()));
         }
     }
 

--- a/Resources/doc/annotations/security.rst
+++ b/Resources/doc/annotations/security.rst
@@ -54,6 +54,15 @@ Here is another example, making use of multiple functions in the expression::
     {
     }
 
+The message parameter allows you to customize the text shown to the user at the exception or error pages::
+
+    /**
+     * @Security("is_granted('POST_SHOW', post)", message="You have no rights to view this post.")
+     */
+    public function showAction(Post $post)
+    {
+    }
+
 .. note::
 
     Defining a ``Security`` annotation has the same effect as defining an

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -155,7 +155,7 @@ This example shows all the available annotations in action::
          * @ParamConverter("post", class="SensioBlogBundle:Post")
          * @Template("SensioBlogBundle:Annot:show.html.twig", vars={"post"})
          * @Cache(smaxage="15", lastmodified="post.getUpdatedAt()", etag="'Post' ~ post.getId() ~ post.getUpdatedAt()")
-         * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)")
+         * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)", message="You have no access to this post")
          */
         public function showAction(Post $post)
         {


### PR DESCRIPTION
Replaces #311 

> Custom exception messages are essential to generate customized exception and error page views. Default message is not always acceptable to be displayed to the end user at least because of disclosing security expression used to restrict access.