### PR TITLE
Throw a RuntimeException is now thrown when a reserved variable is used in a security expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.0
 ---
 
+ * a RuntimeException is now thrown when a reserved variable is used in a security expression
  * added cache-control max-stale support
  * renamed setETag to setEtag for consistency with Symfony core (use Etag in @Cache now instead of ETag)
  * added must-revalidate support for @Cache annotation

--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -92,6 +92,11 @@ class SecurityListener implements EventSubscriberInterface
             'auth_checker' => $this->authChecker,
         );
 
+        if ($diff = array_intersect(array_keys($variables), array_keys($request->attributes->all()))) {
+            $singular = 1 === count($diff);
+            throw new \RuntimeException(sprintf('Request attribute%s "%s" cannot be defined as %s collide%s with built-in security expression variables.', $singular ? '' : 's', implode('", "', $diff), $singular ? 'it' : 'they', $singular ? 's' : ''));
+        }
+
         // controller variables should also be accessible
         return array_merge($request->attributes->all(), $variables);
     }


### PR DESCRIPTION
closes #411