### PR TITLE
Add autoconfigure tag for ParamConverterInterface

### DIFF
--- a/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\DependencyInjection;
 
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -46,6 +47,9 @@ class SensioFrameworkExtraExtension extends Extension
 
         if ($config['request']['converters']) {
             $annotationsToLoad[] = 'converters.xml';
+
+            $container->registerForAutoconfiguration(ParamConverterInterface::class)
+                ->addTag('request.param_converter');
 
             $container->setParameter('sensio_framework_extra.disabled_converters', is_string($config['request']['disable']) ? implode(',', $config['request']['disable']) : $config['request']['disable']);
 

--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -296,7 +296,9 @@ on the request attributes, it should set an attribute named
 ``$configuration->getName()``, which stores an object of class
 ``$configuration->getClass()``.
 
-To register your converter service, you must add a tag to your service:
+If you're using service `auto-registration and autoconfiguration`_,
+you're done! Your converter will automatically be used.
+If not, you must add a tag to your service:
 
 .. configuration-block::
 
@@ -330,3 +332,5 @@ definition.
 .. tip::
 
    Use the ``DoctrineParamConverter`` class as a template for your own converters.
+
+.. _auto-registration and autoconfiguration: http://symfony.com/doc/current/service_container/3.3-di-changes.html


### PR DESCRIPTION
I tried to add the same behavior in `converters.xml` but it was not working..

```xml
 <instanceof id="Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface" public="true">
            <tag name="request.param_converter" />
</instanceof>
```