### PR TITLE
Changing how IsGranted works so that it can use all controller args as subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.0
+---
+ * Changed the `@Security` annotation to use arguments from argument
+   converters as expression variables.
+
 4.0
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ CHANGELOG
 5.0
 ---
  * Changed the `@Security` annotation to use arguments from argument
-   converters as expression variables.
+   resolvers as expression variables.
+
+ * The `@IsGranted` annotation now also supports using arguments from the
+   argument resolvers as the subject.
 
 4.0
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 5.0
 ---
+
  * Changed the `@Security` annotation to use arguments from argument
    resolvers as expression variables.
 

--- a/EventListener/IsGrantedListener.php
+++ b/EventListener/IsGrantedListener.php
@@ -13,7 +13,8 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -26,14 +27,16 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class IsGrantedListener implements EventSubscriberInterface
 {
+    private $argumentMetadataFactory;
     private $authChecker;
 
-    public function __construct(AuthorizationCheckerInterface $authChecker = null)
+    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory, AuthorizationCheckerInterface $authChecker = null)
     {
+        $this->argumentMetadataFactory = $argumentMetadataFactory;
         $this->authChecker = $authChecker;
     }
 
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelControllerArguments(FilterControllerArgumentsEvent $event)
     {
         $request = $event->getRequest();
         /** @var $configurations IsGranted[] */
@@ -42,20 +45,19 @@ class IsGrantedListener implements EventSubscriberInterface
         }
 
         if (null === $this->authChecker) {
-            throw new \LogicException('To use the @IsGranted tag, you need to install symfony/security-bundle.');
+            throw new \LogicException('To use the @IsGranted tag, you need to install symfony/security-bundle and configure your security system.');
         }
+
+        $arguments = $this->getArguments($event);
 
         foreach ($configurations as $configuration) {
             $subject = null;
             if ($configuration->getSubject()) {
-                if (!$request->attributes->has($configuration->getSubject())) {
-                    $allAttributes = $request->attributes->all();
-                    // remove one attribute we know is noise in the error message
-                    unset($allAttributes['_is_granted']);
-                    throw new \RuntimeException(sprintf('Could not find the subject "%s" for the @IsGranted annotation. Available attributes are: %s', $configuration->getSubject(), implode(', ', array_keys($allAttributes))));
+                if (!isset($arguments[$configuration->getSubject()])) {
+                    throw new \RuntimeException(sprintf('Could not find the subject "%s" for the @IsGranted annotation. Try adding a "$%s" argument to your controller method.', $configuration->getSubject(), $configuration->getSubject()));
                 }
 
-                $subject = $request->attributes->get($configuration->getSubject());
+                $subject = $arguments[$configuration->getSubject()];
             }
 
             if (!$this->authChecker->isGranted($configuration->getAttributes(), $subject)) {
@@ -70,6 +72,23 @@ class IsGrantedListener implements EventSubscriberInterface
                 throw new AccessDeniedException($message);
             }
         }
+    }
+
+    private function getArguments(FilterControllerArgumentsEvent $event)
+    {
+        $namedArguments = $event->getRequest()->attributes->all();
+        $argumentMetadatas = $this->argumentMetadataFactory->createArgumentMetadata($event->getController());
+
+        // loop over each argument value and its name from the metadata
+        foreach ($event->getArguments() as $index => $argument) {
+            if (!isset($argumentMetadatas[$index])) {
+                throw new \LogicException(sprintf('Could not find any argument metadata for argument %d of the controller.', $index));
+            }
+
+            $namedArguments[$argumentMetadatas[$index]->getName()] = $argument;
+        }
+
+        return $namedArguments;
     }
 
     private function getIsGrantedString(IsGranted $isGranted)
@@ -95,6 +114,6 @@ class IsGrantedListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(KernelEvents::CONTROLLER => 'onKernelController');
+        return array(KernelEvents::CONTROLLER_ARGUMENTS => 'onKernelControllerArguments');
     }
 }

--- a/Request/ArgumentNameConverter.php
+++ b/Request/ArgumentNameConverter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request;
+
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class ArgumentNameConverter
+{
+    private $argumentMetadataFactory;
+
+    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory)
+    {
+        $this->argumentMetadataFactory = $argumentMetadataFactory;
+    }
+
+    /**
+     * Returns an associative array of the controller arguments for the event.
+     *
+     * @param FilterControllerArgumentsEvent $event
+     *
+     * @return array
+     */
+    public function getControllerArguments(FilterControllerArgumentsEvent $event)
+    {
+        $namedArguments = $event->getRequest()->attributes->all();
+        $argumentMetadatas = $this->argumentMetadataFactory->createArgumentMetadata($event->getController());
+        $controllerArguments = $event->getArguments();
+
+        foreach ($argumentMetadatas as $index => $argumentMetadata) {
+            if ($argumentMetadata->isVariadic()) {
+                // set the rest of the arguments as this arg's value
+                $namedArguments[$argumentMetadata->getName()] = array_values($controllerArguments);
+
+                break;
+            }
+
+            if (!isset($controllerArguments[$index])) {
+                throw new \LogicException(sprintf('Could not find an argument value for argument %d of the controller.', $index));
+            }
+
+            $namedArguments[$argumentMetadata->getName()] = $controllerArguments[$index];
+            // unset so that we can handle variadic arguments easily
+            unset($controllerArguments[$index]);
+        }
+
+        return $namedArguments;
+    }
+}

--- a/Request/ArgumentNameConverter.php
+++ b/Request/ArgumentNameConverter.php
@@ -42,7 +42,7 @@ class ArgumentNameConverter
         foreach ($argumentMetadatas as $index => $argumentMetadata) {
             if ($argumentMetadata->isVariadic()) {
                 // set the rest of the arguments as this arg's value
-                $namedArguments[$argumentMetadata->getName()] = array_values($controllerArguments);
+                $namedArguments[$argumentMetadata->getName()] = array_slice($controllerArguments, $index);
 
                 break;
             }
@@ -52,8 +52,6 @@ class ArgumentNameConverter
             }
 
             $namedArguments[$argumentMetadata->getName()] = $controllerArguments[$index];
-            // unset so that we can handle variadic arguments easily
-            unset($controllerArguments[$index]);
         }
 
         return $namedArguments;

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -17,6 +17,7 @@
         <service id="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" class="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" public="false" />
 
         <service id="Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener" class="Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener" public="false">
+            <argument type="service" id="argument_metadata_factory" />
             <argument type="service" id="security.authorization_checker" on-invalid="null" />
             <tag name="kernel.event_subscriber" />
         </service>

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -6,6 +6,7 @@
 
     <services>
         <service id="Sensio\Bundle\FrameworkExtraBundle\EventListener\SecurityListener" class="Sensio\Bundle\FrameworkExtraBundle\EventListener\SecurityListener" public="false">
+            <argument type="service" id="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" />
             <argument type="service" id="sensio_framework_extra.security.expression_language" on-invalid="null" />
             <argument type="service" id="security.authentication.trust_resolver" on-invalid="null" />
             <argument type="service" id="security.role_hierarchy" on-invalid="null" />
@@ -17,9 +18,13 @@
         <service id="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" class="Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage" public="false" />
 
         <service id="Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener" class="Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener" public="false">
-            <argument type="service" id="argument_metadata_factory" />
+            <argument type="service" id="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" />
             <argument type="service" id="security.authorization_checker" on-invalid="null" />
             <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" class="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" public="false">
+            <argument type="service" id="argument_metadata_factory" />
         </service>
     </services>
 </container>

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -23,7 +23,7 @@
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" class="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" public="false">
+        <service id="Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter" public="false">
             <argument type="service" id="argument_metadata_factory" />
         </service>
     </services>

--- a/Tests/EventListener/IsGrantedListenerTest.php
+++ b/Tests/EventListener/IsGrantedListenerTest.php
@@ -110,10 +110,13 @@ class IsGrantedListenerTest extends \PHPUnit_Framework_TestCase
         $isGranted = new IsGranted(array('attributes' => $attributes, 'subject' => $subject));
         $request = $this->createRequest($isGranted);
 
-        $this->expectException(AccessDeniedException::class);
-        $this->expectExceptionMessage($expectedMessage);
-
-        $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+        try {
+            $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+            $this->fail();
+        } catch (\Exception $e) {
+            $this->assertEquals(AccessDeniedException::class, get_class($e));
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
     }
 
     public function getAccessDeniedMessageTests()

--- a/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
+++ b/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
@@ -13,6 +13,7 @@ namespace Tests\Fixtures\FooBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,6 +22,7 @@ class IsGrantedController
     /**
      * @Route("/is_granted/anonymous")
      * @IsGranted("IS_AUTHENTICATED_ANONYMOUSLY")
+     * @Security("is_granted('IS_AUTHENTICATED_ANONYMOUSLY')")
      */
     public function someAction()
     {
@@ -30,6 +32,7 @@ class IsGrantedController
     /**
      * @Route("/is_granted/request/attribute/args/{a}")
      * @IsGranted("ISGRANTED_VOTER", subject="a")
+     * @Security("is_granted('ISGRANTED_VOTER', a)")
      */
     public function some2Action($a)
     {
@@ -39,9 +42,20 @@ class IsGrantedController
     /**
      * @Route("/is_granted/resolved/args")
      * @IsGranted("ISGRANTED_VOTER", subject="foo")
+     * @Security("is_granted('ISGRANTED_VOTER', foo)")
      */
     public function some3Action(Request $foo)
     {
         return new Response('yay3');
+    }
+
+    /**
+     * @Route("/is_granted/variadic/args", defaults={"params"={"foo", "bar"}})
+     * @Security("is_granted('ISGRANTED_VOTER', params)")
+     * @IsGranted("ISGRANTED_VOTER", subject="params")
+     */
+    public function some4Action(Request $foo, ...$params)
+    {
+        return new Response('yay4');
     }
 }

--- a/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
+++ b/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
@@ -48,14 +48,4 @@ class IsGrantedController
     {
         return new Response('yay3');
     }
-
-    /**
-     * @Route("/is_granted/variadic/args", defaults={"params"={"foo", "bar"}})
-     * @Security("is_granted('ISGRANTED_VOTER', params)")
-     * @IsGranted("ISGRANTED_VOTER", subject="params")
-     */
-    public function some4Action(Request $foo, ...$params)
-    {
-        return new Response('yay4');
-    }
 }

--- a/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
+++ b/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Fixtures\FooBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsGrantedController
+{
+    /**
+     * @Route("/is_granted/anonymous")
+     * @IsGranted("IS_AUTHENTICATED_ANONYMOUSLY")
+     */
+    public function someAction()
+    {
+        return new Response('yay1');
+    }
+
+    /**
+     * @Route("/is_granted/request/attribute/args/{a}")
+     * @IsGranted("ISGRANTED_VOTER", subject="a")
+     */
+    public function some2Action($a)
+    {
+        return new Response('yay2');
+    }
+
+    /**
+     * @Route("/is_granted/resolved/args")
+     * @IsGranted("ISGRANTED_VOTER", subject="foo")
+     */
+    public function some3Action(Request $foo)
+    {
+        return new Response('yay3');
+    }
+}

--- a/Tests/Fixtures/FooBundle/ControllerWithVariadics/IsGrantedControllerWithVariadics.php
+++ b/Tests/Fixtures/FooBundle/ControllerWithVariadics/IsGrantedControllerWithVariadics.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Fixtures\FooBundle\ControllerWithVariadics;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsGrantedControllerWithVariadics
+{
+    /**
+     * @Security("is_granted('ISGRANTED_VOTER', params)")
+     * @IsGranted("ISGRANTED_VOTER", subject="params")
+     */
+    public function some4Action(Request $foo, ...$params)
+    {
+        return new Response('yay4');
+    }
+}

--- a/Tests/Fixtures/FooBundle/Security/IsGrantedVoter.php
+++ b/Tests/Fixtures/FooBundle/Security/IsGrantedVoter.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Fixtures\FooBundle\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Used in the function test IsGrantedTest.
+ */
+class IsGrantedVoter extends Voter
+{
+    protected function supports($attribute, $subject)
+    {
+        return 'ISGRANTED_VOTER' === $attribute;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        // we use these specific conditions in the test
+        if ('allow_access' === $subject) {
+            return true;
+        }
+
+        if ($subject instanceof Request) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Tests/Fixtures/FooBundle/Security/IsGrantedVoter.php
+++ b/Tests/Fixtures/FooBundle/Security/IsGrantedVoter.php
@@ -36,6 +36,10 @@ class IsGrantedVoter extends Voter
             return true;
         }
 
+        if (array('foo', 'bar') === $subject) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -26,6 +26,7 @@ class TestKernel extends Kernel
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new \Tests\Fixtures\FooBundle\FooBundle(),
             new \Tests\Fixtures\ActionArgumentsBundle\ActionArgumentsBundle(),
         );

--- a/Tests/Fixtures/config/config.yml
+++ b/Tests/Fixtures/config/config.yml
@@ -27,3 +27,31 @@ services:
     test.action_arguments:
         class:  Tests\Fixtures\ActionArgumentsBundle\Controller\ActionArgumentsController
         public: true
+
+    test.is_granted_voter:
+        class: Tests\Fixtures\FooBundle\Security\IsGrantedVoter
+        public: false
+        tags:
+            - { name: security.voter }
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    johannes: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        # This firewall doesn't make sense in combination with the rest of the
+        # configuration file, but it's here for testing purposes (do not use
+        # this file in a real world scenario though)
+        login_form:
+            pattern: ^/login$
+            security: false
+
+        default:
+            form_login: ~
+            anonymous: ~

--- a/Tests/Fixtures/config/nullable_type/routing.yml
+++ b/Tests/Fixtures/config/nullable_type/routing.yml
@@ -2,6 +2,12 @@ foo_bundle:
     resource: "@FooBundle/Controller"
     type: annotation
 
+foo_bundle_with_variadics:
+    path: /is_granted/variadic/args
+    defaults:
+        _controller: '\Tests\Fixtures\FooBundle\ControllerWithVariadics\IsGrantedControllerWithVariadics::some4Action'
+        params: ["foo", "bar"]
+
 action_arguments_bundle:
     resource: "@ActionArgumentsBundle/Controller"
     type: annotation

--- a/Tests/Fixtures/config/routing.yml
+++ b/Tests/Fixtures/config/routing.yml
@@ -2,6 +2,12 @@ foo_bundle:
     resource: "@FooBundle/Controller"
     type: annotation
 
+foo_bundle_with_variadics:
+    path: /is_granted/variadic/args
+    defaults:
+        _controller: '\Tests\Fixtures\FooBundle\ControllerWithVariadics\IsGrantedControllerWithVariadics::some4Action'
+        params: ["foo", "bar"]
+
 action_arguments_bundle:
     resource: "@ActionArgumentsBundle/Controller/ActionArgumentsController.php"
     type: annotation

--- a/Tests/Functional/IsGrantedTest.php
+++ b/Tests/Functional/IsGrantedTest.php
@@ -33,7 +33,7 @@ class IsGrantedTest extends WebTestCase
     public function testIsGrantedSubjectFromArguments()
     {
         $client = self::createClient();
-        $client->request('GET', '/is_granted/resolved/args');
+        $client->request('GET', '/is_granted/variadic/args');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
     }

--- a/Tests/Functional/IsGrantedTest.php
+++ b/Tests/Functional/IsGrantedTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class IsGrantedTest extends WebTestCase
+{
+    public function testIsGrantedNoSubject()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/is_granted/anonymous');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testIsGrantedSubjectFromAttributes()
+    {
+        $client = self::createClient();
+        // allow_access is a special string allowed by the voter
+        $client->request('GET', '/is_granted/request/attribute/args/allow_access');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testIsGrantedSubjectFromAttributesDenied()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/is_granted/request/attribute/args/no_access');
+
+        // a redirect
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+    }
+
+    public function testIsGrantedSubjectFromArguments()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/is_granted/resolved/args');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+}

--- a/Tests/Functional/IsGrantedTest.php
+++ b/Tests/Functional/IsGrantedTest.php
@@ -30,6 +30,9 @@ class IsGrantedTest extends WebTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
     }
 
+    /**
+     * @requires PHP 5.6
+     */
     public function testIsGrantedSubjectFromArguments()
     {
         $client = self::createClient();

--- a/Tests/Request/ArgumentNameConverterTest.php
+++ b/Tests/Request/ArgumentNameConverterTest.php
@@ -60,5 +60,8 @@ class ArgumentNameConverterTest extends \PHPUnit_Framework_TestCase
         $arg1Metadata = new ArgumentMetadata('arg1Name', 'string', false, false, null);
         $arg2VariadicMetadata = new ArgumentMetadata('arg2Name', 'string', true, false, null);
         yield array(array('arg1Value', 'arg2Value', 'arg3Value'), array($arg1Metadata, $arg2VariadicMetadata), array(), array('arg1Name' => 'arg1Value', 'arg2Name' => array('arg2Value', 'arg3Value')));
+
+        // variadic argument receives no arguments, so becomes an empty array
+        yield array(array('arg1Value'), array($arg1Metadata, $arg2VariadicMetadata), array(), array('arg1Name' => 'arg1Value', 'arg2Name' => array()));
     }
 }

--- a/Tests/Request/ArgumentNameConverterTest.php
+++ b/Tests/Request/ArgumentNameConverterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ArgumentNameConverterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getArgumentTests
+     */
+    public function testGetControllerArguments(array $resolvedArguments, array $argumentMetadatas, array $requestAttributes, array $expectedArguments)
+    {
+        $metadataFactory = $this->getMockBuilder(ArgumentMetadataFactoryInterface::class)->getMock();
+        $metadataFactory->expects($this->any())
+            ->method('createArgumentMetadata')
+            ->will($this->returnValue($argumentMetadatas));
+
+        $request = new Request();
+        $request->attributes->add($requestAttributes);
+
+        $converter = new ArgumentNameConverter($metadataFactory);
+        $event = new FilterControllerArgumentsEvent($this->getMockBuilder(HttpKernelInterface::class)->getMock(), function () { return new Response(); }, $resolvedArguments, $request, null);
+        $actualArguments = $converter->getControllerArguments($event);
+        $this->assertSame($expectedArguments, $actualArguments);
+    }
+
+    public function getArgumentTests()
+    {
+        // everything empty
+        yield array(array(), array(), array(), array());
+
+        // uses request attributes
+        yield array(array(), array(), array('post' => 5), array('post' => 5));
+
+        // resolves argument names correctly
+        $arg1Metadata = new ArgumentMetadata('arg1Name', 'string', false, false, null);
+        $arg2Metadata = new ArgumentMetadata('arg2Name', 'string', false, false, null);
+        yield array(array('arg1Value', 'arg2Value'), array($arg1Metadata, $arg2Metadata), array('post' => 5), array('post' => 5, 'arg1Name' => 'arg1Value', 'arg2Name' => 'arg2Value'));
+
+        // argument names have priority over request attributes
+        yield array(array('arg1Value', 'arg2Value'), array($arg1Metadata, $arg2Metadata), array('arg1Name' => 'differentValue'), array('arg1Name' => 'arg1Value', 'arg2Name' => 'arg2Value'));
+
+        // variadic arguments are resolved correctly
+        $arg1Metadata = new ArgumentMetadata('arg1Name', 'string', false, false, null);
+        $arg2VariadicMetadata = new ArgumentMetadata('arg2Name', 'string', true, false, null);
+        yield array(array('arg1Value', 'arg2Value', 'arg3Value'), array($arg1Metadata, $arg2VariadicMetadata), array(), array('arg1Name' => 'arg1Value', 'arg2Name' => array('arg2Value', 'arg3Value')));
+    }
+}


### PR DESCRIPTION
This *should* work currently:

```
/**
 * @IsGranted("SOME_ATTR", subject="someVar")
 */
public function fooAction(Request $someVar)
```

The `Request $someVar` is resolved with an argument resolver. It should then be available as a subject to `IsGranted()`. But, this currently does not work: *no* arguments from argument resolvers are available (only `$request->attributes` are used as args).

This has been a long-standing issue with `@Security`. This fixes it for `@IsGranted`. Should we fix this also for `@Security`?