### PR TITLE
Declare the sensio_framework_extra.view.guesser service public

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="sensio_framework_extra.view.guesser" class="%sensio_framework_extra.view.guesser.class%">
+        <service id="sensio_framework_extra.view.guesser" class="%sensio_framework_extra.view.guesser.class%" public="true">
             <argument type="service" id="kernel" />
         </service>
     </services>


### PR DESCRIPTION
I've tried out one of my projects with Symfony 4 and ran into an issue with SensioFrameworkExtraBundle.

```
Uncaught PHP Exception Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: "You have requested a non-existent service "sensio_framework_extra.view.guesser"."
```

![bildschirmfoto 2017-10-08 um 16 42 26](https://user-images.githubusercontent.com/1506493/31317815-f7fd1a4a-ac47-11e7-8cc6-1ddafbee94f8.png)

The problem seems to be that the `TemplateListener` pulls a service out of the container that has not explicitly been declared public. This PR fixes the issue.