### PR TITLE
Allow nullable argument parameters

### DIFF
--- a/Request/ArgumentNameConverter.php
+++ b/Request/ArgumentNameConverter.php
@@ -47,7 +47,7 @@ class ArgumentNameConverter
                 break;
             }
 
-            if (!isset($controllerArguments[$index])) {
+            if (!array_key_exists($index, $controllerArguments)) {
                 throw new \LogicException(sprintf('Could not find an argument value for argument %d of the controller.', $index));
             }
 

--- a/Tests/Request/ArgumentNameConverterTest.php
+++ b/Tests/Request/ArgumentNameConverterTest.php
@@ -63,5 +63,10 @@ class ArgumentNameConverterTest extends \PHPUnit_Framework_TestCase
 
         // variadic argument receives no arguments, so becomes an empty array
         yield array(array('arg1Value'), array($arg1Metadata, $arg2VariadicMetadata), array(), array('arg1Name' => 'arg1Value', 'arg2Name' => array()));
+
+        // resolves nullable argument correctly
+        $arg1Metadata = new ArgumentMetadata('arg1Name', 'string', false, false, null);
+        $arg2NullableMetadata = new ArgumentMetadata('arg2Name', 'string', false, false, true);
+        yield array(array('arg1Value', null), array($arg1Metadata, $arg2Metadata), array('post' => 5), array('post' => 5, 'arg1Name' => 'arg1Value', 'arg2Name' => null));
     }
 }


### PR DESCRIPTION
I just update to the last version and my nullable parameters doesn't work

The following code work with the 4.0 version of the bundle, but not with the 5.0

```
/**
 * @Security("has_role('ROLE_ADMIN')")
 */
public function listAction(User $currentUser, ?Customer $customer = null)
{
}
```