### PR TITLE
Fixing an issue where you cannot have a Request $request argument

### DIFF
--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -113,7 +113,7 @@ class SecurityListener implements EventSubscriberInterface
                 }
             }
 
-            if (!empty($diff)) {
+            if ($diff) {
                 $singular = 1 === count($diff);
                 if (null !== $this->logger) {
                     $this->logger->warning(sprintf('Controller argument%s "%s" collided with the built-in security expression variables. The built-in value%s are being used for the @Security expression.', $singular ? '' : 's', implode('", "', $diff), $singular ? 's' : ''));

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="security.role_hierarchy" on-invalid="null" />
             <argument type="service" id="security.token_storage" on-invalid="null" />
             <argument type="service" id="security.authorization_checker" on-invalid="null" />
+            <argument type="service" id="logger" on-invalid="null" />
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/Tests/EventListener/SecurityListenerTest.php
+++ b/Tests/EventListener/SecurityListenerTest.php
@@ -22,34 +22,6 @@ use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
 class SecurityListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Request attribute "user" cannot be defined as it collides with built-in security expression variables.
-     */
-    public function testReservedVariable()
-    {
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
-        $token->expects($this->once())->method('getRoles')->will($this->returnValue(array()));
-
-        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
-        $tokenStorage->expects($this->exactly(2))->method('getToken')->will($this->returnValue($token));
-
-        $authChecker = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')->getMock();
-
-        $trustResolver = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface')->getMock();
-
-        $language = new ExpressionLanguage();
-
-        $argNameConverter = $this->createArgumentNameConverter(array('user' => 'myuser'));
-
-        $listener = new SecurityListener($argNameConverter, $language, $trustResolver, null, $tokenStorage, $authChecker);
-        $request = $this->createRequest(new Security(array('expression' => 'has_role("ROLE_ADMIN") or is_granted("FOO")')));
-
-        $event = new FilterControllerArgumentsEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), function () { return new Response(); }, array(), $request, null);
-
-        $listener->onKernelControllerArguments($event);
-    }
-
-    /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
      */
     public function testAccessDenied()

--- a/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
+++ b/Tests/Fixtures/FooBundle/Controller/IsGrantedController.php
@@ -48,4 +48,14 @@ class IsGrantedController
     {
         return new Response('yay3');
     }
+
+    /**
+     * @Route("/is_granted/resolved/conflict")
+     * @IsGranted("ISGRANTED_VOTER", subject="request")
+     * @Security("is_granted('ISGRANTED_VOTER', request)")
+     */
+    public function someRequestAction(Request $request)
+    {
+        return new Response('yayRequest');
+    }
 }

--- a/Tests/Functional/IsGrantedTest.php
+++ b/Tests/Functional/IsGrantedTest.php
@@ -30,6 +30,22 @@ class IsGrantedTest extends WebTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
     }
 
+    public function testIsGrantedResolvesRequestArgument()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/is_granted/resolved/args');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testRequestArgumentDoesNotConflict()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/is_granted/resolved/conflict');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
     /**
      * @requires PHP 5.6
      */


### PR DESCRIPTION
Hi guys!

Fixes #519. But actually, this wasn't caused by my recent refactoring, it was caused @fabpot in #504 as a way to fix #411 (though I also have a bug in my code, also fixed here).

The problem is: what do we do if the user has an argument named `request` (or `user`)... but we want to pass `request` (or `user`) as a variable to the Security expression? Which should win? In #504, we throw an exception. But this means the user can't have `$request` or `$user` controller arguments when using `@Security`, which is very odd. I've converted to a warning, and we only show it when the values don't actually match. I think this is a good middle ground.

I apologize for not catching this earlier - I *nearly* added a functional test for this originally... but not quite.

Cheers!

