### PR TITLE
Fix branch alias.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0.x-dev"
+            "dev-master": "5.0.x-dev"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Currently, master contains the 5.0.x branch. Let's not confuse Composer with outdated information. 😉 