### PR TITLE
Noted the template/directory change as BC break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ CHANGELOG
  * added @IsGranted() annotation
  * allowed to disable some converters
  * allowed to customize the @security message and status code
- * changed template name generation from camelCase to under_score
+ * [BC BREAK] changed template name generation from camelCase to under_score for both files and directories
  * removed support for bundle inheritance
  * a RuntimeException is now thrown when a reserved variable is used in a security expression
  * added cache-control max-stale support


### PR DESCRIPTION
Fixes #538.

`DefaultIndexController::fooBarAction` produces the following change as of 4.0:
```diff
- DefaultIndex/fooBar.html.twig
+ default_index/foo_bar.html.twig
```

This should've been noted as a BC break when using `@Template()`