### PR TITLE
Fix exception with invalid options in DoctrineParamConverter

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -265,7 +265,7 @@ class DoctrineParamConverter implements ParamConverterInterface
             return false;
         }
 
-        $options = $this->getOptions($configuration);
+        $options = $this->getOptions($configuration, false);
 
         // Doctrine Entity?
         $em = $this->getManager($options['entity_manager'], $configuration->getClass());
@@ -276,7 +276,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         return !$em->getMetadataFactory()->isTransient($configuration->getClass());
     }
 
-    private function getOptions(ParamConverter $configuration)
+    private function getOptions(ParamConverter $configuration, $strict = true)
     {
         $defaultValues = array(
             'entity_manager' => null,
@@ -301,7 +301,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
 
         $extraKeys = array_diff(array_keys($passedOptions), array_keys($defaultValues));
-        if ($extraKeys) {
+        if ($extraKeys && $strict) {
             throw new \InvalidArgumentException(sprintf('Invalid option(s) passed to @%s: %s', $this->getAnnotationName($configuration), implode(', ', $extraKeys)));
         }
 

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -485,6 +485,26 @@ class DoctrineParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($ret, 'Should be supported');
     }
 
+    public function testSupportsWithDifferentConfiguration()
+    {
+        $config = $this->createConfiguration('DateTime', array('format' => \DateTime::ISO8601));
+
+        $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
+        $objectManager->expects($this->never())
+                      ->method('getMetadataFactory');
+
+        $this->registry->expects($this->once())
+                    ->method('getManagers')
+                    ->will($this->returnValue(array($objectManager)));
+
+        $this->registry->expects($this->never())
+                      ->method('getManager');
+
+        $ret = $this->converter->supports($config);
+
+        $this->assertFalse($ret, 'Should not be supported');
+    }
+
     /**
      * @expectedException \LogicException
      */


### PR DESCRIPTION
Fixes #542 

This happened when we added a param converter for a `DateTime` field with the `format` option but without the `converter` option:
```
@ParamConverter("updatedAt", isOptional=true, options={"format"=DateTime::ATOM})
```

While it may be correct that `DoctrineParamConverter` throws an error on unsupported options, doing so in `supports` is invalid.