### PR TITLE
Fix DateTime conversion for optional parameters

### DIFF
--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -40,7 +40,8 @@ class DateTimeParamConverter implements ParamConverterInterface
         $value = $request->attributes->get($param);
 
         if (!$value && $configuration->isOptional()) {
-            return false;
+            $request->attributes->set($param, null);
+            return true;
         }
 
         $class = $configuration->getClass();

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -80,13 +80,13 @@ class DateTimeParamConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyOptionalWithEmptyAttribute()
     {
-        $request = new Request(array(), array(), array('start' => null));
+        $request = new Request(array(), array(), array('start' => ''));
         $config = $this->createConfiguration('DateTime', 'start');
         $config->expects($this->once())
             ->method('isOptional')
             ->will($this->returnValue(true));
 
-        $this->assertFalse($this->converter->apply($request, $config));
+        $this->assertTrue($this->converter->apply($request, $config));
         $this->assertNull($request->attributes->get('start'));
     }
 


### PR DESCRIPTION
With optional parameters, `DateTimeParamConverter` needs to set the value to `null` and mark the value as converted to avoid later type issues. For example, passing an empty string to a controller with a `DateTimeParamConverter` would cause a type mismatch since the original empty string is not replaced with a `null` value.