### PR TITLE
FIX: We no longer use Foo:Bar:index.html.twig

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -147,7 +147,7 @@ This example shows all the available annotations in action::
          * @Route("/{id}")
          * @Method("GET")
          * @ParamConverter("post", class="SensioBlogBundle:Post")
-         * @Template("SensioBlogBundle:Annot:show.html.twig", vars={"post"})
+         * @Template("@SensioBlog/annot/show.html.twig", vars={"post"})
          * @Cache(smaxage="15", lastmodified="post.getUpdatedAt()", etag="'Post' ~ post.getId() ~ post.getUpdatedAt()")
          * @IsGranted("ROLE_SPECIAL_USER")
          * @Security("has_role('ROLE_ADMIN') and is_granted('POST_SHOW', post)")


### PR DESCRIPTION
I noticed that the current documentation on the index page, for the `@Template` annotation, is incorrect (since version 4.0), so this PR fixes that.