### PR TITLE
Make getIdentifier protected to allow override

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -125,7 +125,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         }
     }
 
-    private function getIdentifier(Request $request, $options, $name)
+    protected function getIdentifier(Request $request, $options, $name)
     {
         if (null !== $options['id']) {
             if (!is_array($options['id'])) {


### PR DESCRIPTION
Change the getIdentifier method in the Doctrine param converter from private to protected. This allows overriding the method in classes that extend the param converter. This is useful when you fiddle with
your ID’s in the URL, for example use Hashids.

With the method set to private you can’t override it.