### PR TITLE
Fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /vendor
 coverage
 /Tests/Fixtures/cache
+/Tests/Fixtures/logs
 phpunit.xml
 composer.lock
 /.phpunit
+/.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,10 @@
 <?php
 
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->exclude('Tests/Fixtures/cache')
+    ->in(__DIR__);
+
 return PhpCsFixer\Config::create()
     ->setRules(array(
         '@Symfony' => true,
@@ -10,4 +15,5 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
     ))
     ->setRiskyAllowed(true)
+    ->setFinder($finder)
 ;

--- a/Configuration/Method.php
+++ b/Configuration/Method.php
@@ -18,6 +18,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @Annotation
+ *
  * @deprecated since version 5.2
  */
 class Method extends ConfigurationAnnotation

--- a/Configuration/Route.php
+++ b/Configuration/Route.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\Annotation\Route as BaseRoute;
 /**
  * @author Kris Wallsmith <kris@symfony.com>
  * @Annotation
+ *
  * @deprecated since version 5.2
  */
 class Route extends BaseRoute

--- a/Request/ParamConverter/DateTimeParamConverter.php
+++ b/Request/ParamConverter/DateTimeParamConverter.php
@@ -41,6 +41,7 @@ class DateTimeParamConverter implements ParamConverterInterface
 
         if (!$value && $configuration->isOptional()) {
             $request->attributes->set($param, null);
+
             return true;
         }
 

--- a/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -41,6 +41,9 @@ class AddExpressionLanguageProvidersPassTest extends \PHPUnit\Framework\TestCase
         $this->container->setDefinition('sensio_framework_extra.security.expression_language.default', $this->expressionLangDefinition);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testProcessNoOpNoExpressionLang()
     {
         $this->container->removeDefinition('sensio_framework_extra.security.expression_language.default');

--- a/Tests/DependencyInjection/Compiler/AddParamConverterPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddParamConverterPassTest.php
@@ -42,6 +42,9 @@ class AddParamConverterPassTest extends \PHPUnit\Framework\TestCase
         $this->container->setParameter('sensio_framework_extra.disabled_converters', []);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testProcessNoOpNoManager()
     {
         $this->container->removeDefinition('sensio_framework_extra.converter.manager');

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -23,6 +23,7 @@ class TestKernel extends Kernel
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\MonologBundle\MonologBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),

--- a/Tests/Fixtures/config/config.yml
+++ b/Tests/Fixtures/config/config.yml
@@ -3,6 +3,9 @@ framework:
     secret: test
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
+    fragments:
+        enabled: true
+
 doctrine:
     dbal:
         driver:   pdo_sqlite
@@ -54,3 +57,16 @@ security:
         default:
             form_login: ~
             anonymous: ~
+
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: "%kernel.logs_dir%/console.log"
+            level: critical
+            channels: []
+
+twig:
+    debug: '%kernel.debug%'
+    strict_variables: '%kernel.debug%'
+    exception_controller: twig.controller.exception:showAction

--- a/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DateTimeParamConverterTest.php
@@ -49,32 +49,41 @@ class DateTimeParamConverterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2012-07-21', $request->attributes->get('start')->format('Y-m-d'));
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Invalid date given for parameter "start".
+     */
     public function testApplyInvalidDate404Exception()
     {
         $request = new Request([], [], ['start' => 'Invalid DateTime Format']);
         $config = $this->createConfiguration('DateTime', 'start');
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
         $this->converter->apply($request, $config);
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Invalid date given for parameter "start".
+     */
     public function testApplyWithFormatInvalidDate404Exception()
     {
         $request = new Request([], [], ['start' => '2012-07-21']);
         $config = $this->createConfiguration('DateTime', 'start');
         $config->expects($this->any())->method('getOptions')->will($this->returnValue(['format' => 'd.m.Y']));
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
         $this->converter->apply($request, $config);
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Invalid date given for parameter "start".
+     */
     public function testApplyWithYmdFormatInvalidDate404Exception()
     {
         $request = new Request([], [], ['start' => '2012-21-07']);
         $config = $this->createConfiguration('DateTime', 'start');
         $config->expects($this->any())->method('getOptions')->will($this->returnValue(['format' => 'Y-m-d']));
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid date given for parameter "start".');
         $this->converter->apply($request, $config);
     }
 

--- a/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/Tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -75,13 +75,15 @@ class DoctrineParamConverterTest extends \PHPUnit\Framework\TestCase
         return $config;
     }
 
+    /**
+     * @expectedException \LogicException
+     */
     public function testApplyWithNoIdAndData()
     {
         $request = new Request();
         $config = $this->createConfiguration(null, []);
         $objectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
 
-        $this->setExpectedException('LogicException');
         $this->converter->apply($request, $config);
     }
 

--- a/Tests/Request/ParamConverter/ParamConverterManagerTest.php
+++ b/Tests/Request/ParamConverter/ParamConverterManagerTest.php
@@ -68,6 +68,9 @@ class ParamConverterManagerTest extends \PHPUnit\Framework\TestCase
         $manager->apply(new Request(), $configurations);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testApplyNamedConverter()
     {
         $converter = $this->createParamConverterMock();

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
         "symfony/dom-crawler": "^3.3|^4.0",
         "zendframework/zend-diactoros": "^1.3",
         "doctrine/doctrine-bundle": "^1.6",
-        "doctrine/orm": "^2.5"
+        "doctrine/orm": "^2.5",
+        "symfony/monolog-bundle": "^3.2",
+        "symfony/monolog-bridge": "^3.0|^4.0"
     },
     "suggest": {
         "symfony/psr-http-message-bridge": "To use the PSR-7 converters",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
     <php>
         <server name="KERNEL_CLASS" value="Tests\Fixtures\TestKernel" />
         <server name="KERNEL_DIR" value="Tests/Fixtures/" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="/disabled/" />
     </php>
     <filter>
         <whitelist>


### PR DESCRIPTION
I was about to add my own ParamConverter when I noticed the tests were failing and have been failing for quite some time apparently.

I took the liberty to fix those issues:
- Fixed tests marked as risky
- Logging output to file instead of console
- Fixed setExpectedException method not found exception as it's deprecated and removed
- Fixed php-cs-fixer configuration (was missing finder)
- Fixed things found by php-cs-fixer
- Fixed missing fragments renderer
- Fixed missing deprecated LoggerInterface
- Disable deprecation helper by default