### PR TITLE
[ParamConverters] Hashids Converter

### DIFF
--- a/Request/ParamConverter/HashidsParamConverter.php
+++ b/Request/ParamConverter/HashidsParamConverter.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
+
+use Hashids\Hashids;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * HashidsParamConverter.
+ *
+ * @author Maarten de Boer <maarten@cloudstek.nl>
+ */
+class HashidsParamConverter implements ParamConverterInterface
+{
+    /**
+     * @var ParamConverterInterface|null
+     */
+    protected $inner;
+
+    /**
+     * @var Hashids|null
+     */
+    protected $hashids;
+
+    public function __construct(ParamConverterInterface $inner = null, Hashids $hashids = null)
+    {
+        $this->inner = $inner;
+        $this->hashids = $hashids;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Request $request, ParamConverter $configuration)
+    {
+        $options = $configuration->getOptions();
+        $name = !empty($options['id']) ? $options['id'] : $configuration->getName();
+
+        if (is_array($name)) {
+            $ids = [];
+            foreach ($name as $field) {
+                $request->attributes->set($field, $this->decodeId($request->attributes->get($field)));
+            }
+        } elseif ($request->attributes->has($name)) {
+            $request->attributes->set($name, $this->decodeId($request->attributes->get($name)));
+        } elseif ($request->attributes->has('id') && empty($options['id'])) {
+            $request->attributes->set('id', $this->decodeId($request->attributes->get('id')));
+        }
+
+        return $this->inner->apply($request, $configuration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(ParamConverter $configuration)
+    {
+        if (null === $this->inner || null === $this->hashids) {
+            return false;
+        }
+
+        return $this->inner->supports($configuration);
+    }
+
+    /**
+     * Decode identifier.
+     *
+     * @param string|int|null $id
+     *
+     * @return int|null
+     */
+    protected function decodeId($id)
+    {
+        if (!is_string($id) && !is_int($id)) {
+            return null;
+        }
+
+        if (!empty($id) && is_string($id) && !is_numeric($id)) {
+            $hashid = array_filter($this->hashids->decode($id));
+
+            if (count($hashid) > 0) {
+                $id = (int) $hashid[0];
+            }
+        }
+
+        return (int) $id;
+    }
+}

--- a/Request/ParamConverter/HashidsParamConverter.php
+++ b/Request/ParamConverter/HashidsParamConverter.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
 
-use Hashids\Hashids;
+use Hashids\HashidsInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -28,11 +28,11 @@ class HashidsParamConverter implements ParamConverterInterface
     protected $inner;
 
     /**
-     * @var Hashids|null
+     * @var HashidsInterface|null
      */
     protected $hashids;
 
-    public function __construct(ParamConverterInterface $inner = null, Hashids $hashids = null)
+    public function __construct(ParamConverterInterface $inner = null, HashidsInterface $hashids = null)
     {
         $this->inner = $inner;
         $this->hashids = $hashids;

--- a/Tests/Request/ParamConverter/HashidsParamConverterTest.php
+++ b/Tests/Request/ParamConverter/HashidsParamConverterTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\HashidsParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+
+class HashidsParamConverterTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $innerConverter;
+
+    /**
+     * @var MockObject
+     */
+    private $hashids;
+
+    /**
+     * @var HashidsParamConverter
+     */
+    private $converter;
+
+    public function setUp()
+    {
+        $this->innerConverter = $this->getMockBuilder('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')->getMock();
+        $this->hashids = $this
+            ->getMockBuilder('Hashids\Hashids')
+            ->setMethods(['encode', 'decode'])
+            ->getMock();
+        $this->converter = new HashidsParamConverter($this->innerConverter, $this->hashids);
+    }
+
+    public function testSupports()
+    {
+        $supportedConfig = $this->createConfiguration();
+        $unsupportedConfig = $this->createConfiguration('DateTime');
+
+        $this->innerConverter
+            ->expects($this->at(0))
+            ->method('supports')
+            ->with($supportedConfig)
+            ->willReturn(true);
+
+        $this->innerConverter
+            ->expects($this->at(1))
+            ->method('supports')
+            ->with($unsupportedConfig)
+            ->willReturn(false);
+
+        $this->assertTrue($this->converter->supports($supportedConfig));
+        $this->assertFalse($this->converter->supports($unsupportedConfig));
+    }
+
+    /**
+     * Test apply with id attribute.
+     */
+    public function testApplyDefaultID()
+    {
+        $request = new Request([], [], ['id' => 'olejRejN', 'user' => 2, 'slug' => 'test', 'book' => 'WPe9xdLy']);
+        $config = $this->createConfiguration(null, 'id');
+
+        $this->hashids
+            ->expects($this->once())
+            ->method('decode')
+            ->with($this->equalTo('olejRejN'))
+            ->willReturn([1]);
+
+        $this->innerConverter
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->equalTo($request), $this->equalTo($config));
+
+        $this->converter->apply($request, $config);
+
+        $this->assertEquals(1, $request->attributes->get('id'), "ID hasn't been properly decoded.");
+        $this->assertEquals(2, $request->attributes->get('user'));
+        $this->assertEquals('test', $request->attributes->get('slug'));
+        $this->assertEquals('WPe9xdLy', $request->attributes->get('book'), 'Book attribute has been decoded but was not requested to be decoded.');
+    }
+
+    /**
+     * Test apply with single named attribute.
+     */
+    public function testApplySingleNamedID()
+    {
+        $request = new Request([], [], ['post' => 'olejRejN', 'user' => 2, 'slug' => 'test', 'book' => 'WPe9xdLy']);
+        $config = $this->createConfiguration(null, 'post');
+
+        $this->hashids
+            ->expects($this->once())
+            ->method('decode')
+            ->with($this->equalTo('olejRejN'))
+            ->willReturn([1]);
+
+        $this->innerConverter
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->equalTo($request), $this->equalTo($config));
+
+        $this->converter->apply($request, $config);
+
+        $this->assertEquals(1, $request->attributes->get('post'));
+        $this->assertEquals(2, $request->attributes->get('user'));
+        $this->assertEquals('test', $request->attributes->get('slug'));
+        $this->assertEquals('WPe9xdLy', $request->attributes->get('book'), 'Book attribute has been decoded but was not requested to be decoded.');
+    }
+
+    /**
+     * Test apply with multiple attributes.
+     */
+    public function testApplyMultipleNamedIDs()
+    {
+        $id = ['olejRejN', 'pmbk5ezJ'];
+        $request = new Request([], [], ['post' => $id[0], 'user' => $id[1], 'slug' => 'test', 'book' => 'WPe9xdLy']);
+        $config = $this->createConfiguration(null, ['post', 'user']);
+
+        $this->hashids
+            ->expects($this->at(0))
+            ->method('decode')
+            ->with($this->equalTo($id[0]))
+            ->willReturn([1]);
+
+        $this->hashids
+            ->expects($this->at(1))
+            ->method('decode')
+            ->with($this->equalTo($id[1]))
+            ->willReturn([2]);
+
+        $this->innerConverter
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->equalTo($request), $this->equalTo($config));
+
+        $this->converter->apply($request, $config);
+
+        $this->assertEquals(1, $request->attributes->get('post'));
+        $this->assertEquals(2, $request->attributes->get('user'));
+        $this->assertEquals('test', $request->attributes->get('slug'));
+        $this->assertEquals('WPe9xdLy', $request->attributes->get('book'), 'Book attribute has been decoded but was not requested to be decoded.');
+    }
+
+    /**
+     * Test apply fallback to id attribute for non-existing foo attribute.
+     */
+    public function testApplyNonExistingNamedIDWithDefault()
+    {
+        $request = new Request([], [], ['id' => 'olejRejN', 'user' => 2, 'slug' => 'test', 'book' => 'WPe9xdLy']);
+        $config = $this->createConfiguration(null, 'foo');
+
+        $this->hashids
+            ->expects($this->once())
+            ->method('decode')
+            ->with($this->equalTo('olejRejN'))
+            ->willReturn([1]);
+
+        $this->innerConverter
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->equalTo($request), $this->equalTo($config));
+
+        $this->converter->apply($request, $config);
+
+        $this->assertEquals(1, $request->attributes->get('id'), "ID hasn't been properly decoded.");
+        $this->assertEquals(2, $request->attributes->get('user'));
+        $this->assertEquals('test', $request->attributes->get('slug'));
+        $this->assertEquals('WPe9xdLy', $request->attributes->get('book'), 'Book attribute has been decoded but was not requested to be decoded.');
+    }
+
+    /**
+     * Test apply with non-existing attribute and no id attribute to fall back to.
+     */
+    public function testApplyNonExistingNamedIDWithoutDefault()
+    {
+        $request = new Request([], [], ['user' => 2, 'slug' => 'test', 'book' => 'WPe9xdLy']);
+        $config = $this->createConfiguration(null, 'foo');
+
+        $this->hashids
+            ->expects($this->never())
+            ->method('decode');
+
+        $this->innerConverter
+            ->expects($this->once())
+            ->method('apply')
+            ->with($this->equalTo($request), $this->equalTo($config));
+
+        $this->converter->apply($request, $config);
+
+        $this->assertEquals(2, $request->attributes->get('user'));
+        $this->assertEquals('test', $request->attributes->get('slug'));
+        $this->assertEquals('WPe9xdLy', $request->attributes->get('book'), 'Book attribute has been decoded but was not requested to be decoded.');
+    }
+
+    /**
+     * Create configuration mock.
+     *
+     * @param string|null $class
+     * @param string|null $name
+     *
+     * @return MockObject
+     */
+    protected function createConfiguration($class = null, $name = null)
+    {
+        $config = $this
+            ->getMockBuilder('Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter')
+            ->setMethods(['getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray', 'isOptional'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        if (null !== $name) {
+            $config->expects($this->any())
+                   ->method('getName')
+                   ->will($this->returnValue($name));
+        }
+        if (null !== $class) {
+            $config->expects($this->any())
+                   ->method('getClass')
+                   ->will($this->returnValue($class));
+        }
+
+        return $config;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/orm": "^2.5",
         "symfony/monolog-bridge": "^3.0|^4.0",
         "symfony/monolog-bundle": "^3.2",
-        "hashids/hashids": "^3.0"
+        "hashids/hashids": "^2.0|^3.0"
     },
     "suggest": {
         "symfony/psr-http-message-bridge": "To use the PSR-7 converters",

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,14 @@
         "symfony/dom-crawler": "^3.3|^4.0",
         "zendframework/zend-diactoros": "^1.3",
         "doctrine/doctrine-bundle": "^1.6",
-        "doctrine/orm": "^2.5"
+        "doctrine/orm": "^2.5",
+        "hashids/hashids": "^3.0"
     },
     "suggest": {
         "symfony/psr-http-message-bridge": "To use the PSR-7 converters",
         "symfony/expression-language": "",
-        "symfony/security-bundle": ""
+        "symfony/security-bundle": "",
+        "hashids/hashids": "To use the Hashids converter"
     },
     "autoload": {
         "psr-4": { "Sensio\\Bundle\\FrameworkExtraBundle\\": "" }


### PR DESCRIPTION
ParamConverter that can decode attributes hashed with [Hashids](https://hashids.org) and pass them on to the inner ParamConverter (e.g. DoctrineParamConverter).

As the inner ParamConverter is free to choose I did not include a service definition. To use it you’ll need to add a service definition and set a priority (higher than the inner).

Also see closed PR #567 