### PR TITLE
Make "sensio_framework_extra.router.annotations" disabled by default

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,7 +37,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('router')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->booleanNode('annotations')->defaultTrue()->end()
+                        ->booleanNode('annotations')->defaultFalse()->end()
                     ->end()
                 ->end()
                 ->arrayNode('request')


### PR DESCRIPTION
The config builder was not updated to match the new deprecations introduced in 5.2, then having `sensio_framework_extra.router.annotations` still defaulted to TRUE raises deprecation notices if no `framework_extra.yaml` file (with annotations disabled) is present in the project.