### PR TITLE
Update routing annotations doc as deprecated

### DIFF
--- a/Resources/doc/annotations/routing.rst
+++ b/Resources/doc/annotations/routing.rst
@@ -1,6 +1,12 @@
 @Route and @Method
 ==================
 
+.. caution::
+
+    Routing annotations of the SensioFrameworkExtraBundle are deprecated since version 5.2.
+    Configuring routes with annotations is now a core feature of Symfony. Please use it
+    instead as explained in :doc:`/routing`.
+
 Usage
 -----
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -50,7 +50,7 @@ The default configuration is as follow:
     .. code-block:: yaml
 
         sensio_framework_extra:
-            router:      { annotations: true }
+            router:      { annotations: true } # Deprecated; use routing annotations of Symfony core instead
             request:     { converters: true, auto_convert: true }
             view:        { annotations: true }
             cache:       { annotations: true }


### PR DESCRIPTION
Fixes #568 together with https://github.com/symfony/symfony-docs/pull/9983