### PR TITLE
Added failing test case for template guesser bug

### DIFF
--- a/Tests/Templating/Fixture/Controller/MyAdmin/OutOfBundleExtendingInBundleController.php
+++ b/Tests/Templating/Fixture/Controller/MyAdmin/OutOfBundleExtendingInBundleController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Templating\Fixture\Controller\MyAdmin;
+
+use Sensio\Bundle\FrameworkExtraBundle\Tests\Templating\Fixture\FooBundle\Controller\FooController;
+
+class OutOfBundleExtendingInBundleController extends FooController
+{
+}

--- a/Tests/Templating/TemplateGuesserTest.php
+++ b/Tests/Templating/TemplateGuesserTest.php
@@ -61,6 +61,17 @@ class TemplateGuesserTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('my_admin/out_of_bundle/index.html.twig', (string) $templateReference);
     }
 
+    public function testGuessTemplateWithoutBundleExtendingInBundle()
+    {
+        $templateGuesser = new TemplateGuesser($this->kernel);
+        $templateReference = $templateGuesser->guessTemplateName([
+            new Fixture\Controller\MyAdmin\OutOfBundleExtendingInBundleController(),
+            'indexAction',
+        ], new Request());
+
+        $this->assertEquals('my_admin/out_of_bundle_extending_in_bundle/index.html.twig', (string) $templateReference);
+    }
+
     public function testGuessTemplateWithSubNamespace()
     {
         $templateGuesser = new TemplateGuesser($this->kernel);


### PR DESCRIPTION
In a Symfony 4, if you create a controller in `App\Controller` which extends a controller in a bundle, the `@Template` annotation will try to render the wrong view.

The main controller is not in a bundle, so the guesser will continue with the parent controller, and wrongly guess the parent's bundle.