### PR TITLE
Fix ConversionException resulting in a 500 instead 404

### DIFF
--- a/Request/ParamConverter/DoctrineParamConverter.php
+++ b/Request/ParamConverter/DoctrineParamConverter.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
 
+use Doctrine\DBAL\Types\ConversionException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
@@ -141,6 +142,8 @@ class DoctrineParamConverter implements ParamConverterInterface
             return $om->getRepository($class)->$method($id);
         } catch (NoResultException $e) {
             return;
+        } catch (ConversionException $e) {
+            return;
         }
     }
 
@@ -235,6 +238,8 @@ class DoctrineParamConverter implements ParamConverterInterface
             return $em->getRepository($class)->$repositoryMethod($criteria);
         } catch (NoResultException $e) {
             return;
+        } catch (ConversionException $e) {
+            return;
         }
     }
 
@@ -268,6 +273,8 @@ class DoctrineParamConverter implements ParamConverterInterface
         try {
             return $this->language->evaluate($expression, $variables);
         } catch (NoResultException $e) {
+            return;
+        } catch (ConversionException $e) {
             return;
         } catch (SyntaxError $e) {
             throw new \LogicException(sprintf('Error parsing expression -- %s -- (%s)', $expression, $e->getMessage()), 0, $e);


### PR DESCRIPTION
Hey all!

We've found that when you're trying to use the `DoctrineParamConverter` with a custom Doctrine Type that could throw a `ConversionException`, this exception is not treated like a 404. Instead, it propagates until a 500 is returned. This PR aims to fix this behaviour.

Practical example:
`GET /resource/{id}` (i.e. `GET /resource/this_is_not_an_uuid`) where the id is a string representation of ramsey/uuid. Using https://github.com/ramsey/uuid-doctrine the uuid type throws the ConversionException where the specified value is not a valid uuid.
