### PR TITLE
[DoctrineParamConverter][Docs] Add evict_cache documentation

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -235,6 +235,8 @@ A number of ``options`` are available on the ``@ParamConverter`` or
     {
     }
 
+* ``evict_cache`` If true, forces Doctrine to always fetch the entity from the database instead of cache.
+
 DateTime Converter
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The documentation of `evict_cache` option was missing from `DoctrineParamConverter`. 
`map_method_signature` is undocumented too, but it is deprecated.