### PR TITLE
[Annotation] Add custom exceptions for IsGranted annotation

### DIFF
--- a/Exception/IsGrantedAccessDeniedException.php
+++ b/Exception/IsGrantedAccessDeniedException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Exception;
+
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class IsGrantedAccessDeniedException extends AccessDeniedException implements IsGrantedExceptionInterface
+{
+    private $attributes = [];
+    private $subject;
+
+    public function __construct($attributes, $subject, $message)
+    {
+        $this->attributes = $attributes;
+        $this->subject = $subject;
+
+        parent::__construct($message);
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+}

--- a/Exception/IsGrantedExceptionInterface.php
+++ b/Exception/IsGrantedExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Exception;
+
+interface IsGrantedExceptionInterface
+{
+    public function getAttributes();
+
+    public function getSubject();
+}

--- a/Exception/IsGrantedHttpException.php
+++ b/Exception/IsGrantedHttpException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class IsGrantedHttpException extends HttpException implements IsGrantedExceptionInterface
+{
+    private $attributes = [];
+    private $subject;
+
+    public function __construct($attributes, $subject, $statusCode, $message)
+    {
+        $this->attributes = $attributes;
+        $this->subject = $subject;
+
+        parent::__construct($statusCode, $message);
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+}

--- a/Tests/EventListener/IsGrantedListenerTest.php
+++ b/Tests/EventListener/IsGrantedListenerTest.php
@@ -13,13 +13,13 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\IsGrantedListener;
+use Sensio\Bundle\FrameworkExtraBundle\Exception\IsGrantedAccessDeniedException;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -114,7 +114,7 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
             $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertEquals(AccessDeniedException::class, \get_class($e));
+            $this->assertEquals(IsGrantedAccessDeniedException::class, \get_class($e));
             $this->assertEquals($expectedMessage, $e->getMessage());
         }
     }
@@ -127,7 +127,7 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException        \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedException        \Sensio\Bundle\FrameworkExtraBundle\Exception\IsGrantedHttpException
      * @expectedExceptionMessage Not found
      */
     public function testNotFoundHttpException()


### PR DESCRIPTION
I encountered recently a use case, where I need to intercept the exception thrown by the `@IsGranted` annotation, but currently I'm unable to identify such an exception, as the exceptions thrown are generic.

My proposal here is to use specific exceptions so that I can catch these one and know that they came from `@IsGranted`. I added the `attributes` and the `subject` used when the exception is thrown as they are valuable (at least for my use case) in this context.

Another solution could be to dispatch an event also.