### PR TITLE
Allow arrays of parameters to be used with @IsGranted

### DIFF
--- a/Tests/EventListener/IsGrantedListenerTest.php
+++ b/Tests/EventListener/IsGrantedListenerTest.php
@@ -77,6 +77,27 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
         $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
     }
 
+    public function testIsGrantedSubjectFromArgumentsWithArray()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        // createRequest() puts 2 IsGranted annotations into the config
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            // the subject => arg2name will eventually resolve to the 2nd argument, which has this value
+            ->with('ROLE_ADMIN', [
+                'arg1Name' => 'arg1Value',
+                'arg2Name' => 'arg2Value',
+            ])
+            ->will($this->returnValue(true));
+
+        // create metadata for 2 named args for the controller
+        $listener = new IsGrantedListener($this->createArgumentNameConverter(['arg1Name' => 'arg1Value', 'arg2Name' => 'arg2Value']), $authChecker);
+        $isGranted = new IsGranted(['attributes' => 'ROLE_ADMIN', 'subject' => ['arg1Name', 'arg2Name']]);
+        $request = $this->createRequest($isGranted);
+
+        $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
This will allow `@IsGranted` annotation to pass an array of parameters to the security checker.  For example:

```
@IsGranted("CAN_DO_THINGS", subject={"thing1", "thing2"})
```

The equivalent can be done using an expression in the `@Security` annotation, but using the `@IsGranted` annotation provides better readability.