### PR TITLE
Add example of `@IsGranted()` with multiple roles.

### DIFF
--- a/Resources/doc/annotations/security.rst
+++ b/Resources/doc/annotations/security.rst
@@ -34,7 +34,7 @@ on variables passed to the controller::
     /**
      * @Route("/posts/{id}")
      *
-     * @IsGranted("ROLE_ADMIN")
+     * @IsGranted({"ROLE_ADMIN", "ROLE_SYSTEM"})
      * @IsGranted("POST_SHOW", subject="post")
      */
     public function show(Post $post)


### PR DESCRIPTION
There are use cases of `@IsGranted()` where we want to check that a user has any one of multiple roles that don't intersect in the role hierarchy. I've seen this is two separate occasions already, especially with people migrating away from the JMSSecurityExtraBundle.

Does including one example make sense? Should there be a separate sentence or paragraph pointing this out?