### PR TITLE
Fixed behaviour on Symfony 3.4

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\Proxy;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -41,7 +41,7 @@ class ControllerListener implements EventSubscriberInterface
      * controllers annotations like the template to render or HTTP caching
      * configuration.
      */
-    public function onKernelController(ControllerEvent $event)
+    public function onKernelController(KernelEvent $event)
     {
         $controller = $event->getController();
 

--- a/EventListener/HttpCacheListener.php
+++ b/EventListener/HttpCacheListener.php
@@ -14,8 +14,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -40,7 +39,7 @@ class HttpCacheListener implements EventSubscriberInterface
     /**
      * Handles HTTP validation headers.
      */
-    public function onKernelController(ControllerEvent $event)
+    public function onKernelController(KernelEvent $event)
     {
         $request = $event->getRequest();
         if (!$configuration = $request->attributes->get('_cache')) {
@@ -79,7 +78,7 @@ class HttpCacheListener implements EventSubscriberInterface
     /**
      * Modifies the response to apply HTTP cache headers when needed.
      */
-    public function onKernelResponse(ResponseEvent $event)
+    public function onKernelResponse(KernelEvent $event)
     {
         $request = $event->getRequest();
 

--- a/EventListener/IsGrantedListener.php
+++ b/EventListener/IsGrantedListener.php
@@ -14,7 +14,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -36,7 +36,7 @@ class IsGrantedListener implements EventSubscriberInterface
         $this->authChecker = $authChecker;
     }
 
-    public function onKernelControllerArguments(ControllerArgumentsEvent $event)
+    public function onKernelControllerArguments(KernelEvent $event)
     {
         $request = $event->getRequest();
         /** @var $configurations IsGranted[] */

--- a/EventListener/ParamConverterListener.php
+++ b/EventListener/ParamConverterListener.php
@@ -15,7 +15,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -50,7 +50,7 @@ class ParamConverterListener implements EventSubscriberInterface
     /**
      * Modifies the ParamConverterManager instance.
      */
-    public function onKernelController(ControllerEvent $event)
+    public function onKernelController(KernelEvent $event)
     {
         $controller = $event->getController();
         $request = $event->getRequest();

--- a/EventListener/PsrResponseListener.php
+++ b/EventListener/PsrResponseListener.php
@@ -14,7 +14,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -37,7 +37,7 @@ class PsrResponseListener implements EventSubscriberInterface
     /**
      * Do the conversion if applicable and update the response of the event.
      */
-    public function onKernelView(ViewEvent $event)
+    public function onKernelView(KernelEvent $event)
     {
         $controllerResult = $event->getControllerResult();
 

--- a/EventListener/TemplateListener.php
+++ b/EventListener/TemplateListener.php
@@ -17,8 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -43,7 +42,7 @@ class TemplateListener implements EventSubscriberInterface
      * Guesses the template name to render and its variables and adds them to
      * the request object.
      */
-    public function onKernelController(ControllerEvent $event)
+    public function onKernelController(KernelEvent $event)
     {
         $request = $event->getRequest();
         $template = $request->attributes->get('_template');
@@ -68,7 +67,7 @@ class TemplateListener implements EventSubscriberInterface
      * Renders the template and initializes a new response object with the
      * rendered template content.
      */
-    public function onKernelView(ViewEvent $event)
+    public function onKernelView(KernelEvent $event)
     {
         /* @var Template $template */
         $request = $event->getRequest();

--- a/Tests/EventListener/ControllerListenerTest.php
+++ b/Tests/EventListener/ControllerListenerTest.php
@@ -22,6 +22,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooController
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerParamConverterAtClassAndMethod;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ControllerListenerTest extends \PHPUnit\Framework\TestCase
@@ -131,7 +132,9 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
     {
         $mockKernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['', '']);
 
-        return new ControllerEvent($mockKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
+        $eventClass = class_exists(ControllerEvent::class) ? ControllerEvent::class : FilterControllerEvent::class;
+
+        return new $eventClass($mockKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
     private function getReadedCache()

--- a/Tests/EventListener/IsGrantedListenerTest.php
+++ b/Tests/EventListener/IsGrantedListenerTest.php
@@ -17,6 +17,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -156,7 +157,9 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
 
     private function createFilterControllerEvent(Request $request)
     {
-        return new ControllerArgumentsEvent($this->getMockBuilder(HttpKernelInterface::class)->getMock(), function () {
+        $eventClass = class_exists(ControllerArgumentsEvent::class) ? ControllerArgumentsEvent::class : FilterControllerArgumentsEvent::class;
+
+        return new $eventClass($this->getMockBuilder(HttpKernelInterface::class)->getMock(), function () {
             return new Response();
         }, [], $request, null);
     }

--- a/Tests/EventListener/ParamConverterListenerTest.php
+++ b/Tests/EventListener/ParamConverterListenerTest.php
@@ -16,6 +16,7 @@ use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerNullableParameter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 class ParamConverterListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -26,9 +27,10 @@ class ParamConverterListenerTest extends \PHPUnit\Framework\TestCase
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = new Request();
+        $eventClass = class_exists(ControllerEvent::class) ? ControllerEvent::class : FilterControllerEvent::class;
 
         $listener = new ParamConverterListener($this->getParamConverterManager($request, []));
-        $event = new ControllerEvent($kernel, $controllerCallable, $request, null);
+        $event = new $eventClass($kernel, $controllerCallable, $request, null);
 
         $listener->onKernelController($event);
     }
@@ -48,11 +50,12 @@ class ParamConverterListenerTest extends \PHPUnit\Framework\TestCase
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = new Request([], [], ['date' => '2014-03-14 09:00:00']);
+        $eventClass = class_exists(ControllerEvent::class) ? ControllerEvent::class : FilterControllerEvent::class;
 
         $converter = new ParamConverter(['name' => 'date', 'class' => 'DateTime']);
 
         $listener = new ParamConverterListener($this->getParamConverterManager($request, ['date' => $converter]));
-        $event = new ControllerEvent($kernel, $controllerCallable, $request, null);
+        $event = new $eventClass($kernel, $controllerCallable, $request, null);
 
         $listener->onKernelController($event);
     }
@@ -65,12 +68,13 @@ class ParamConverterListenerTest extends \PHPUnit\Framework\TestCase
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = new Request();
+        $eventClass = class_exists(ControllerEvent::class) ? ControllerEvent::class : FilterControllerEvent::class;
 
         $converter = new ParamConverter(['name' => 'param', 'class' => 'DateTime']);
         $converter->setIsOptional($isOptional);
 
         $listener = new ParamConverterListener($this->getParamConverterManager($request, ['param' => $converter]), true);
-        $event = new ControllerEvent(
+        $event = new $eventClass(
             $kernel,
             [
                 new FooControllerNullableParameter(),
@@ -99,9 +103,10 @@ class ParamConverterListenerTest extends \PHPUnit\Framework\TestCase
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = new Request([], [], ['date' => '2014-03-14 09:00:00']);
+        $eventClass = class_exists(ControllerEvent::class) ? ControllerEvent::class : FilterControllerEvent::class;
 
         $listener = new ParamConverterListener($this->getParamConverterManager($request, []), false);
-        $event = new ControllerEvent($kernel, $controllerCallable, $request, null);
+        $event = new $eventClass($kernel, $controllerCallable, $request, null);
 
         $listener->onKernelController($event);
     }

--- a/Tests/EventListener/PsrResponseListenerTest.php
+++ b/Tests/EventListener/PsrResponseListenerTest.php
@@ -14,6 +14,8 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\PsrResponseListener;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -45,16 +47,17 @@ class PsrResponseListenerTest extends \PHPUnit\Framework\TestCase
 
     private function createEventMock($controllerResult)
     {
+        $eventClass = class_exists(ViewEvent::class) ? ViewEvent::class : GetResponseForControllerResultEvent::class;
+
         $event = $this
-            ->getMockBuilder('Symfony\Component\HttpKernel\Event\ViewEvent')
+            ->getMockBuilder($eventClass)
             ->disableOriginalConstructor()
-            ->getMock()
-        ;
+            ->getMock();
+
         $event
             ->expects($this->any())
             ->method('getControllerResult')
-            ->willReturn($controllerResult)
-        ;
+            ->willReturn($controllerResult);
 
         return $event;
     }


### PR DESCRIPTION
Not 100% sure if  this is the "proper" way to handle those event class changes properly - but at least now tests are ok with 3.4 and 4.3 - although I don't like to use that generic `KernelEvent` type on those listener classes - but didn't found another solution to fix that.

If there is another solution for that I'm like to hear that - so that I could improve this PR.

Related to #625