### PR TITLE
Fix has_role compatibility in Symfony 3.4

### DIFF
--- a/EventListener/SecurityListener.php
+++ b/EventListener/SecurityListener.php
@@ -98,6 +98,10 @@ class SecurityListener implements EventSubscriberInterface
             } else {
                 $roles = $token->getRoles();
             }
+
+            $roles = array_map(function ($role) {
+                return $role->getRole();
+            }, $roles);
         }
 
         $variables = [


### PR DESCRIPTION
Fixes #628 

Looked into tests too, but didn't see any simple way to write a test for 3.4 only, while avoiding deprecations