### PR TITLE
Improve DateTimeParamConverter documentation

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -257,8 +257,8 @@ is accepted. You can be stricter with input given through the options::
 
     /**
      * @Route("/blog/archive/{start}/{end}")
-     * @ParamConverter("start", options={"format": "Y-m-d"})
-     * @ParamConverter("end", options={"format": "Y-m-d"})
+     * @ParamConverter("start", options={"format": "!Y-m-d"})
+     * @ParamConverter("end", options={"format": "!Y-m-d"})
      */
     public function archive(\DateTime $start, \DateTime $end)
     {


### PR DESCRIPTION
With `Y-m-d` format you don't care about the time. In this case I think it's better to force midnight instead of the current time.