### PR TITLE
use Symfony\Component\Routing\Annotation\Route;

### DIFF
--- a/Resources/doc/annotations/converters.rst
+++ b/Resources/doc/annotations/converters.rst
@@ -8,7 +8,7 @@ The ``@ParamConverter`` annotation calls *converters* to convert request
 parameters to objects. These objects are stored as request attributes and so
 they can be injected as controller method arguments::
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 
     /**


### PR DESCRIPTION
Shouldn't we read `use Symfony\Component\Routing\Annotation\Route;`?