### PR TITLE
rm dependency on doctrine/persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "symfony/framework-bundle": "^3.4|^4.3",
         "symfony/dependency-injection": "^3.4|^4.3",
         "symfony/http-kernel": "^3.4|^4.3",
-        "doctrine/annotations": "^1.0",
-        "doctrine/persistence": "^1.0"
+        "doctrine/annotations": "^1.0"
     },
     "require-dev": {
         "symfony/expression-language": "^3.4|^4.3",


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/33164

- make `doctrine/persistence` optional since it will be required transitively anyway via the ORM/ODM that is required for using `DoctrineParamConverter`