### PR TITLE
Ensure owner of Template is not null

### DIFF
--- a/Configuration/Template.php
+++ b/Configuration/Template.php
@@ -45,7 +45,7 @@ class Template extends ConfigurationAnnotation
      *
      * @var array
      */
-    private $owner;
+    private $owner = [];
 
     /**
      * Returns the array of templates variables.


### PR DESCRIPTION
Some libraries trust definition of getOwner method, but it will return null if no owner was set. My personal experience with this was Rector which crashes, as it passses output of this method to function requiring array. Rather than contributing cast patch to rector, I think it would be better to add the missing default directly here.