### PR TITLE
Add cache-control `stale-while-revalidate` and `stale-if-error` support

### DIFF
--- a/src/Configuration/Cache.php
+++ b/src/Configuration/Cache.php
@@ -86,6 +86,22 @@ class Cache extends ConfigurationAnnotation
     private $maxStale;
 
     /**
+     * stale-while-revalidate Cache-Control header
+     * It can be expressed in seconds or with a relative time format (1 day, 2 weeks, ...).
+     *
+     * @var int|string
+     */
+    private $staleWhileRevalidate;
+
+    /**
+     * stale-if-error Cache-Control header
+     * It can be expressed in seconds or with a relative time format (1 day, 2 weeks, ...).
+     *
+     * @var int|string
+     */
+    private $staleIfError;
+
+    /**
      * Returns the expiration date for the Expires header field.
      *
      * @return string
@@ -271,6 +287,46 @@ class Cache extends ConfigurationAnnotation
     public function setMaxStale($maxStale)
     {
         $this->maxStale = $maxStale;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getStaleWhileRevalidate()
+    {
+        return $this->staleWhileRevalidate;
+    }
+
+    /**
+     * @param int|string $staleWhileRevalidate
+     *
+     * @return self
+     */
+    public function setStaleWhileRevalidate($staleWhileRevalidate)
+    {
+        $this->staleWhileRevalidate = $staleWhileRevalidate;
+
+        return $this;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getStaleIfError()
+    {
+        return $this->staleIfError;
+    }
+
+    /**
+     * @param int|string $staleIfError
+     *
+     * @return self
+     */
+    public function setStaleIfError($staleIfError)
+    {
+        $this->staleIfError = $staleIfError;
+
+        return $this;
     }
 
     /**

--- a/src/EventListener/HttpCacheListener.php
+++ b/src/EventListener/HttpCacheListener.php
@@ -115,6 +115,18 @@ class HttpCacheListener implements EventSubscriberInterface
             $response->headers->addCacheControlDirective('max-stale', $stale);
         }
 
+        if (!$response->headers->hasCacheControlDirective('stale-while-revalidate') && null !== $staleWhileRevalidate = $configuration->getStaleWhileRevalidate()) {
+            $staleWhileRevalidate = $this->convertToSecondsIfNeeded($staleWhileRevalidate);
+
+            $response->headers->addCacheControlDirective('stale-while-revalidate', $staleWhileRevalidate);
+        }
+
+        if (!$response->headers->hasCacheControlDirective('stale-if-error') && null !== $staleIfError = $configuration->getStaleIfError()) {
+            $staleIfError = $this->convertToSecondsIfNeeded($staleIfError);
+
+            $response->headers->addCacheControlDirective('stale-if-error', $staleIfError);
+        }
+
         if (!$response->headers->has('Expires') && null !== $configuration->getExpires()) {
             $date = \DateTime::createFromFormat('U', strtotime($configuration->getExpires()), new \DateTimeZone('UTC'));
             $response->setExpires($date);

--- a/src/Resources/doc/annotations/cache.rst
+++ b/src/Resources/doc/annotations/cache.rst
@@ -100,6 +100,8 @@ Annotation                                                              Response
 ``@Cache(smaxage="15")``                                                ``$response->setSharedMaxAge()``
 ``@Cache(maxage="15")``                                                 ``$response->setMaxAge()``
 ``@Cache(maxstale="15")``                                               ``$response->headers->addCacheControlDirective('max-stale', 15)``
+``@Cache(staleWhileRevalidate="15")``                                   ``$response->headers->addCacheControlDirective('stale-while-revalidate', 15)``
+``@Cache(staleIfError="15")``                                           ``$response->headers->addCacheControlDirective('stale-if-error', 15)``
 ``@Cache(vary={"Cookie"})``                                             ``$response->setVary()``
 ``@Cache(public=true)``                                                 ``$response->setPublic()``
 ``@Cache(lastModified="post.getUpdatedAt()")``                          ``$response->setLastModified()``


### PR DESCRIPTION
These headers can be used by proxy cache (Varnish, Nginx) in order to serve stale contents.
