### PR TITLE
Add stampede protection to Cache annotation for smaxage and maxage

### DIFF
--- a/src/Configuration/Cache.php
+++ b/src/Configuration/Cache.php
@@ -35,12 +35,26 @@ class Cache extends ConfigurationAnnotation
     private $maxage;
 
     /**
+     * The percentage to use for the maxage stampede protection.
+     *
+     * @var float|null
+     */
+    private $maxageVariation;
+
+    /**
      * The number of seconds that the response is considered fresh by a public
      * cache like a reverse proxy cache.
      *
      * @var int
      */
     private $smaxage;
+
+    /**
+     * The percentage to use for the smaxage stampede protection.
+     *
+     * @var float|null
+     */
+    private $smaxageVariation;
 
     /**
      * Whether the response is public or not.
@@ -142,6 +156,21 @@ class Cache extends ConfigurationAnnotation
         return $this->maxage;
     }
 
+    public function setMaxAgeVariation(?float $maxageVariation): void
+    {
+        $this->maxageVariation = $maxageVariation;
+    }
+
+    /**
+     * Returns the variation in percentage.
+     *
+     * @return int|null
+     */
+    public function getMaxAgeVariation(): ?float
+    {
+        return $this->maxageVariation;
+    }
+
     /**
      * Sets the number of seconds for the s-maxage cache-control header field.
      *
@@ -161,6 +190,16 @@ class Cache extends ConfigurationAnnotation
     public function getSMaxAge()
     {
         return $this->smaxage;
+    }
+
+    public function setSMaxAgeVariation(?float $smaxageVariation): void
+    {
+        $this->smaxageVariation = $smaxageVariation;
+    }
+
+    public function getSMaxAgeVariation(): ?float
+    {
+        return $this->smaxageVariation;
     }
 
     /**

--- a/src/EventListener/HttpCacheListener.php
+++ b/src/EventListener/HttpCacheListener.php
@@ -95,6 +95,7 @@ class HttpCacheListener implements EventSubscriberInterface
 
         if (!$response->headers->hasCacheControlDirective('s-maxage') && null !== $age = $configuration->getSMaxAge()) {
             $age = $this->convertToSecondsIfNeeded($age);
+            $age = $this->applyVariation($age, $configuration->getSMaxAgeVariation());
 
             $response->setSharedMaxAge($age);
         }
@@ -105,6 +106,7 @@ class HttpCacheListener implements EventSubscriberInterface
 
         if (!$response->headers->hasCacheControlDirective('max-age') && null !== $age = $configuration->getMaxAge()) {
             $age = $this->convertToSecondsIfNeeded($age);
+            $age = $this->applyVariation($age, $configuration->getMaxAgeVariation());
 
             $response->setMaxAge($age);
         }
@@ -191,5 +193,21 @@ class HttpCacheListener implements EventSubscriberInterface
         }
 
         return $time;
+    }
+
+    /**
+     * Apply stampede protection to the given time.
+     */
+    private function applyVariation(int $time, ?float $variation): int
+    {
+        if (null === $variation) {
+            return $time;
+        }
+
+        try {
+            return random_int($time, $time + $time * $variation);
+        } catch (\Exception $e) {
+            return $time;
+        }
     }
 }


### PR DESCRIPTION
Hi,

This PR add stampede protection for Cache annotation for smaxage and maxage attributes.

```
@Cache(smaxage=3600, smaxageVariation=0.1)
```

This will add up to 10% to the smaxage. 