### PR TITLE
Add throw_notfound option to ParamConverter

### DIFF
--- a/src/Request/ParamConverter/DoctrineParamConverter.php
+++ b/src/Request/ParamConverter/DoctrineParamConverter.php
@@ -88,14 +88,14 @@ class DoctrineParamConverter implements ParamConverterInterface
                 $object = $this->findViaExpression($class, $request, $expr, $options, $configuration);
 
                 if (null === $object) {
-                    $errorMessage = sprintf('The expression "%s" returned null', $expr);
+                    $errorMessage = sprintf('The expression "%s" returned null.', $expr);
                 }
             } else {
                 // find by identifier?
                 $object = $this->find($class, $request, $options, $name, $id);
 
                 if (null === $object && isset($id)) {
-                    $errorMessage = sprintf('No object identified by "%s"', $id);
+                    $errorMessage = sprintf('No object identified by "%s".', $id);
                     if ($options['throw_notfound']) {
                         $throwNotFound = true;
                     }
@@ -107,7 +107,7 @@ class DoctrineParamConverter implements ParamConverterInterface
 
                     if (null === $object && $criteria) {
                         $errorMessage = sprintf(
-                            'No object identified by {%s}',
+                            'No object identified by {%s}.',
                             implode(', ', array_map(function ($k, $v) {
                                 return sprintf('%s: "%s"', $k, $v);
                             }, array_keys($criteria), $criteria))
@@ -302,7 +302,7 @@ class DoctrineParamConverter implements ParamConverterInterface
         try {
             return $this->language->evaluate($expression, $variables);
         } catch (SyntaxError $e) {
-            throw new \LogicException(sprintf('Error parsing expression -- %s -- (%s)', $expression, $e->getMessage()), 0, $e);
+            throw new \LogicException(sprintf('Error parsing expression -- "%s" -- (%s).', $expression, $e->getMessage()), 0, $e);
         }
     }
 
@@ -345,7 +345,7 @@ class DoctrineParamConverter implements ParamConverterInterface
 
         $extraKeys = array_diff(array_keys($passedOptions), array_keys($this->defaultOptions));
         if ($extraKeys && $strict) {
-            throw new \InvalidArgumentException(sprintf('Invalid option(s) passed to @%s: %s', $this->getAnnotationName($configuration), implode(', ', $extraKeys)));
+            throw new \InvalidArgumentException(sprintf('Invalid option(s) passed to @%s: "%s".', $this->getAnnotationName($configuration), implode(', ', $extraKeys)));
         }
 
         return array_replace($this->defaultOptions, $passedOptions);

--- a/src/Request/ParamConverter/DoctrineParamConverter.php
+++ b/src/Request/ParamConverter/DoctrineParamConverter.php
@@ -110,7 +110,7 @@ class DoctrineParamConverter implements ParamConverterInterface
                             'No object identified by {%s}',
                             implode(', ', array_map(function ($k, $v) {
                                 return sprintf('%s: "%s"', $k, $v);
-                            }, \array_keys($criteria), $criteria))
+                            }, array_keys($criteria), $criteria))
                         );
                         if ($options['throw_notfound']) {
                             $throwNotFound = true;

--- a/src/Request/ParamConverter/DoctrineParamConverter.php
+++ b/src/Request/ParamConverter/DoctrineParamConverter.php
@@ -128,8 +128,10 @@ class DoctrineParamConverter implements ParamConverterInterface
 
         $id = $this->getIdentifier($request, $options, $name);
 
-        if (false === $id || null === $id) {
+        if (false === $id) {
             return false;
+        } elseif (null === $id) {
+            return null;
         }
 
         if ($options['repository_method']) {

--- a/src/Resources/doc/annotations/converters.rst
+++ b/src/Resources/doc/annotations/converters.rst
@@ -208,6 +208,9 @@ A number of ``options`` are available on the ``@ParamConverter`` or
 * ``strip_null`` If true, then when ``findOneBy()`` is used, any values that are
   ``null`` will not be used for the query.
 
+* ``throw_notfound`` If true, invalid values (object not found or bad format)
+  trigger a ``404`` error on optional parameters, while null values pass.
+
 * ``entity_manager`` By default, the Doctrine converter uses the *default* entity
   manager, but you can configure this::
 

--- a/tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -281,7 +281,7 @@ class DoctrineParamConverterTest extends \PHPUnit\Framework\TestCase
             ->method('getManagerForClass')
             ->with('stdClass')
             ->willReturn($manager);
-        
+
         $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
         $manager->expects($this->once())
             ->method('getRepository')

--- a/tests/Request/ParamConverter/DoctrineParamConverterTest.php
+++ b/tests/Request/ParamConverter/DoctrineParamConverterTest.php
@@ -223,23 +223,7 @@ class DoctrineParamConverterTest extends \PHPUnit\Framework\TestCase
 
         $config = $this->createConfiguration('stdClass', [], 'arg', null);
 
-        $classMetadata = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')->getMock();
-        $manager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $manager->expects($this->once())
-            ->method('getClassMetadata')
-            ->with('stdClass')
-            ->willReturn($classMetadata);
-
-        $objectRepository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
-        $this->registry->expects($this->once())
-              ->method('getManagerForClass')
-              ->with('stdClass')
-              ->willReturn($manager);
-
-        $manager->expects($this->never())->method('getRepository');
-
-        $objectRepository->expects($this->never())->method('find');
-        $objectRepository->expects($this->never())->method('findOneBy');
+        $this->registry->expects($this->never())->method('getManagerForClass');
 
         $ret = $this->converter->apply($request, $config);
 


### PR DESCRIPTION
### New option
The proposed changes add a new boolean option `throw_notfound`.
When set to true, the `DoctrineParamConverter` throws a `NotFoundHttpException` for optional parameters if identifier for find() or search criteria for findOneBy() are given and no corresponding object can be found or value conversion by Doctrine fails.

```php
/**
 * @Route("/foo/bar/{id}")
 * @ParamConverter("baz", options={"throw_notfound": true})
 */
public function __invoke(?Baz $baz) {
```

```php
/**
 * @Route("/foo/{bar}/{baz}")
 * @ParamConverter("foo", options={"throw_notfound": true})
 */
public function __invoke(?Foo $foo) {
```

### Prevent running findOneBy() for identifier

When an identifier parameter was set to null, `DoctrineParamConverter::apply()` triggered a database query with `WHERE id IS NULL` per `findOneBy()`.
The proposed changes prevent null value for identifiers to fall through to `DoctrineParamConverter::findOneBy()`.
