### PR TITLE
Set attributes and subject to AccessDeniedException

### DIFF
--- a/src/EventListener/IsGrantedListener.php
+++ b/src/EventListener/IsGrantedListener.php
@@ -82,7 +82,11 @@ class IsGrantedListener implements EventSubscriberInterface
                     throw new HttpException($statusCode, $message);
                 }
 
-                throw new AccessDeniedException($message);
+                $accessDeniedException = new AccessDeniedException($message);
+                $accessDeniedException->setAttributes($configuration->getAttributes());
+                $accessDeniedException->setSubject($subject);
+
+                throw $accessDeniedException;
             }
         }
     }

--- a/tests/EventListener/IsGrantedListenerTest.php
+++ b/tests/EventListener/IsGrantedListenerTest.php
@@ -135,6 +135,12 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
         } catch (\Exception $e) {
             $this->assertEquals(AccessDeniedException::class, \get_class($e));
             $this->assertEquals($expectedMessage, $e->getMessage());
+            $this->assertEquals($attributes, $e->getAttributes());
+            if (null !== $subject) {
+                $this->assertEquals('bar', $e->getSubject());
+            } else {
+                $this->assertNull($e->getSubject());
+            }
         }
     }
 


### PR DESCRIPTION
fix #692 

I've confirmed both `AccessDeniedException::$attributes` and `AccessDeniedException::$subject` exist in Symfony4.4+.
This Bundle restricts Symfony version to 4.4 or 5.1, so I think this PullRequest can be merged to master.


