### PR TITLE
Remove reference to deprecated behavior

### DIFF
--- a/src/Resources/doc/annotations/security.rst
+++ b/src/Resources/doc/annotations/security.rst
@@ -34,7 +34,7 @@ on variables passed to the controller::
     /**
      * @Route("/posts/{id}")
      *
-     * @IsGranted({"ROLE_ADMIN", "ROLE_SYSTEM"})
+     * @IsGranted("ROLE_ADMIN")
      * @IsGranted("POST_SHOW", subject="post")
      */
     public function show(Post $post)


### PR DESCRIPTION
`@IsGranted` does not accept arrays since symfony 4.4/5.0, keeping it in the documentation can lead to misunderstanding like in symfony/symfony#37685.