### PR TITLE
Add consistency by always throwing an HttpException

### DIFF
--- a/src/EventListener/IsGrantedListener.php
+++ b/src/EventListener/IsGrantedListener.php
@@ -15,10 +15,10 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * Handles the IsGranted annotation on controllers.
@@ -82,7 +82,7 @@ class IsGrantedListener implements EventSubscriberInterface
                     throw new HttpException($statusCode, $message);
                 }
 
-                throw new AccessDeniedException($message);
+                throw new AccessDeniedHttpException($message);
             }
         }
     }

--- a/src/EventListener/SecurityListener.php
+++ b/src/EventListener/SecurityListener.php
@@ -16,12 +16,12 @@ use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 /**
@@ -62,7 +62,7 @@ class SecurityListener implements EventSubscriberInterface
         }
 
         if (null === $this->tokenStorage->getToken()) {
-            throw new AccessDeniedException('No user token or you forgot to put your controller behind a firewall while using a @Security tag.');
+            throw new AccessDeniedHttpException('No user token or you forgot to put your controller behind a firewall while using a @Security tag.');
         }
 
         if (null === $this->language) {
@@ -75,7 +75,7 @@ class SecurityListener implements EventSubscriberInterface
                     throw new HttpException($statusCode, $configuration->getMessage());
                 }
 
-                throw new AccessDeniedException($configuration->getMessage() ?: sprintf('Expression "%s" denied access.', $configuration->getExpression()));
+                throw new AccessDeniedHttpException($configuration->getMessage() ?: sprintf('Expression "%s" denied access.', $configuration->getExpression()));
             }
         }
     }

--- a/tests/EventListener/IsGrantedListenerTest.php
+++ b/tests/EventListener/IsGrantedListenerTest.php
@@ -17,9 +17,9 @@ use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -133,7 +133,7 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
             $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertEquals(AccessDeniedException::class, \get_class($e));
+            $this->assertEquals(AccessDeniedHttpException::class, \get_class($e));
             $this->assertEquals($expectedMessage, $e->getMessage());
         }
     }

--- a/tests/EventListener/SecurityListenerTest.php
+++ b/tests/EventListener/SecurityListenerTest.php
@@ -18,12 +18,13 @@ use Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class SecurityListenerTest extends \PHPUnit\Framework\TestCase
 {
     public function testAccessDenied()
     {
-        $this->expectException(\Symfony\Component\Security\Core\Exception\AccessDeniedException::class);
+        $this->expectException(AccessDeniedHttpException::class);
 
         $request = $this->createRequest(new Security(['expression' => 'is_granted("ROLE_ADMIN") or is_granted("FOO")']));
         $event = new ControllerArgumentsEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), function () {


### PR DESCRIPTION
Before, the listener was mixing 
```
Symfony\Component\Security\Core\Exception\AccessDeniedException
```
with 
```
use Symfony\Component\HttpKernel\Exception\HttpException;
```

I think we should use 
```
use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
```
instead because it extends HttpException.
