### PR TITLE
Allow enabling null subject for IsGranted

### DIFF
--- a/src/Configuration/IsGranted.php
+++ b/src/Configuration/IsGranted.php
@@ -34,6 +34,13 @@ class IsGranted extends ConfigurationAnnotation
     private $subject;
 
     /**
+     * Defines if subject can be null/not set
+     *
+     * @var bool
+     */
+    private $nullableSubject = false;
+
+    /**
      * The message of the exception - has a nice default if not set.
      *
      * @var string
@@ -68,6 +75,16 @@ class IsGranted extends ConfigurationAnnotation
     public function getSubject()
     {
         return $this->subject;
+    }
+
+    public function isSubjectNullable()
+    {
+        return $this->nullableSubject;
+    }
+
+    public function setNullableSubject($nullableSubject)
+    {
+        $this->nullableSubject = $nullableSubject;
     }
 
     public function getMessage()

--- a/src/Configuration/IsGranted.php
+++ b/src/Configuration/IsGranted.php
@@ -34,7 +34,7 @@ class IsGranted extends ConfigurationAnnotation
     private $subject;
 
     /**
-     * Defines if subject can be null/not set
+     * Defines if subject can be null/not set.
      *
      * @var bool
      */

--- a/src/EventListener/IsGrantedListener.php
+++ b/src/EventListener/IsGrantedListener.php
@@ -60,13 +60,13 @@ class IsGrantedListener implements EventSubscriberInterface
                 if (\is_array($subjectRef)) {
                     foreach ($subjectRef as $ref) {
                         $subject[$ref] = $arguments[$ref] ?? null;
-                        if (is_null($subject[$ref]) && !$subjectNullable) {
+                        if (null === $subject[$ref] && !$subjectNullable) {
                             throw $this->createMissingSubjectException($ref);
                         }
                     }
                 } else {
                     $subject = $arguments[$subjectRef] ?? null;
-                    if (is_null($subject) && !$subjectNullable) {
+                    if (null === $subject && !$subjectNullable) {
                         throw $this->createMissingSubjectException($subjectRef);
                     }
                 }

--- a/src/EventListener/IsGrantedListener.php
+++ b/src/EventListener/IsGrantedListener.php
@@ -56,20 +56,19 @@ class IsGrantedListener implements EventSubscriberInterface
             $subject = null;
 
             if ($subjectRef) {
+                $subjectNullable = $configuration->isSubjectNullable();
                 if (\is_array($subjectRef)) {
                     foreach ($subjectRef as $ref) {
-                        if (!isset($arguments[$ref])) {
+                        $subject[$ref] = $arguments[$ref] ?? null;
+                        if (is_null($subject[$ref]) && !$subjectNullable) {
                             throw $this->createMissingSubjectException($ref);
                         }
-
-                        $subject[$ref] = $arguments[$ref];
                     }
                 } else {
-                    if (!isset($arguments[$subjectRef])) {
+                    $subject = $arguments[$subjectRef] ?? null;
+                    if (is_null($subject) && !$subjectNullable) {
                         throw $this->createMissingSubjectException($subjectRef);
                     }
-
-                    $subject = $arguments[$subjectRef];
                 }
             }
 

--- a/tests/EventListener/IsGrantedListenerTest.php
+++ b/tests/EventListener/IsGrantedListenerTest.php
@@ -109,6 +109,38 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
         $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
     }
 
+    public function testNoExceptionWhenMissingSubjectAttributeWithAllowedNullableSubject()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            ->willReturn(true);
+        $listener = new IsGrantedListener($this->createArgumentNameConverter([]), $authChecker);
+        $isGranted = new IsGranted(['attributes' => 'ROLE_ADMIN', 'subject' => 'non_existent', 'nullableSubject' => true]);
+        $request = $this->createRequest($isGranted);
+        $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+    }
+
+    public function testNullValuePassedToCheckerWhenMissingSubjectAttributeWithAllowedNullableSubject()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            // the subject => arg2name will eventually resolve to the 2nd argument, which has this value
+            ->with('ROLE_ADMIN', [
+                'arg1Name' => null,
+                'arg2Name' => 'arg2Value',
+            ])
+            ->willReturn(true);
+
+
+        $listener = new IsGrantedListener($this->createArgumentNameConverter(['arg2Name' => 'arg2Value']), $authChecker);
+        $isGranted = new IsGranted(['attributes' => 'ROLE_ADMIN', 'subject' => ['arg1Name', 'arg2Name'], 'nullableSubject' => true]);
+        $request = $this->createRequest($isGranted);
+        $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+    }
+
     /**
      * @dataProvider getAccessDeniedMessageTests
      */

--- a/tests/EventListener/IsGrantedListenerTest.php
+++ b/tests/EventListener/IsGrantedListenerTest.php
@@ -127,13 +127,11 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
 
         $authChecker->expects($this->exactly(2))
             ->method('isGranted')
-            // the subject => arg2name will eventually resolve to the 2nd argument, which has this value
             ->with('ROLE_ADMIN', [
                 'arg1Name' => null,
                 'arg2Name' => 'arg2Value',
             ])
             ->willReturn(true);
-
 
         $listener = new IsGrantedListener($this->createArgumentNameConverter(['arg2Name' => 'arg2Value']), $authChecker);
         $isGranted = new IsGranted(['attributes' => 'ROLE_ADMIN', 'subject' => ['arg1Name', 'arg2Name'], 'nullableSubject' => true]);


### PR DESCRIPTION
**What is changed with this PR?**
Enable allowing null subject in IsGranted annotation.

**Why this feature was created?**
In one of my projects I have nullable action argument and voter that supports nullable subject. Unfortunately without allowing null subject I can't use IsGranted annotation. 