### PR TITLE
Support using `resolve_target_entities` in DoctrineParamConverter

### DIFF
--- a/src/Request/ParamConverter/DoctrineParamConverter.php
+++ b/src/Request/ParamConverter/DoctrineParamConverter.php
@@ -304,7 +304,7 @@ class DoctrineParamConverter implements ParamConverterInterface
             return false;
         }
 
-        return $em->getClassMetadata($configuration->getClass()) !== null;
+        return null !== $em->getClassMetadata($configuration->getClass());
     }
 
     private function getOptions(ParamConverter $configuration, $strict = true)


### PR DESCRIPTION
Doctrine ORM provides a way to use Interfaces e. g. in Association Mappings. Then [a config setting named `resolve_target_entities`](https://symfony.com/doc/current/doctrine/resolve_target_entity.html) can be used to supply an Interface-to-Classname mapping. Whenever Doctrine ORM encounters one of the mapped interfaces while loading metadata, it will fall back to the mapped class instead.

This PR aims to support this feature in the `DoctrineParamConverter` as well. 

To go with the example from the above documentation section, `@ParamConverter("...", class="App\Model\InvoiceSubjectInterface")` would pick up the mapping to the concrete `App\Entity\Customer` class and pass an instance of that into the controller.

The main challenge is that inside `\Doctrine\Persistence\AbstractManagerRegistry`, the `getManagerForClass()` method only looks at the `isTransient()` metadata property to make a quick decision if something is an entity that could be loaded.

`isTransient()`, however, is always `false` for interfaces. The target entity resolution only happens inside Doctrines MetadataFactory when actually loading metadata.

So, to support this new use case, we cannot use `getManagerForClass()` but need to be a bit more elaborate. But basically, the code now present here is close to the one used inside `AbstractManagerRegistry`. In particular, it avoids to fetch Managers (expensive services?) as much as the previous implementation.