### PR TITLE
Add PHP 8.0 attributes support

### DIFF
--- a/src/Configuration/Cache.php
+++ b/src/Configuration/Cache.php
@@ -17,6 +17,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  * @author Fabien Potencier <fabien@symfony.com>
  * @Annotation
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Cache extends ConfigurationAnnotation
 {
     /**
@@ -30,7 +31,7 @@ class Cache extends ConfigurationAnnotation
      * The number of seconds that the response is considered fresh by a private
      * cache like a web browser.
      *
-     * @var int
+     * @var int|string|null
      */
     private $maxage;
 
@@ -38,7 +39,7 @@ class Cache extends ConfigurationAnnotation
      * The number of seconds that the response is considered fresh by a public
      * cache like a reverse proxy cache.
      *
-     * @var int
+     * @var int|string|null
      */
     private $smaxage;
 
@@ -100,6 +101,42 @@ class Cache extends ConfigurationAnnotation
      * @var int|string
      */
     private $staleIfError;
+
+    /**
+     * @param int|string|null $maxage
+     * @param int|string|null $smaxage
+     * @param int|string|null $maxstale
+     * @param int|string|null $staleWhileRevalidate
+     * @param int|string|null $staleIfError
+     */
+    public function __construct(
+        array $values = [],
+        string $expires = null,
+        $maxage = null,
+        $smaxage = null,
+        bool $public = false,
+        bool $mustRevalidate = false,
+        array $vary = [],
+        ?string $lastModified = null,
+        ?string $etag = null,
+        $maxstale = null,
+        $staleWhileRevalidate = null,
+        $staleIfError = null
+    ) {
+        $values['expires'] = $values['expires'] ?? $expires;
+        $values['maxage'] = $values['maxage'] ?? $maxage;
+        $values['smaxage'] = $values['smaxage'] ?? $smaxage;
+        $values['public'] = $values['public'] ?? $public;
+        $values['mustRevalidate'] = $values['mustRevalidate'] ?? $mustRevalidate;
+        $values['vary'] = $values['vary'] ?? $vary;
+        $values['lastModified'] = $values['lastModified'] ?? $lastModified;
+        $values['Etag'] = $values['Etag'] ?? $etag;
+        $values['maxstale'] = $values['maxstale'] ?? $maxstale;
+        $values['staleWhileRevalidate'] = $values['staleWhileRevalidate'] ?? $staleWhileRevalidate;
+        $values['staleIfError'] = $values['staleIfError'] ?? $staleIfError;
+
+        parent::__construct($values);
+    }
 
     /**
      * Returns the expiration date for the Expires header field.

--- a/src/Configuration/Entity.php
+++ b/src/Configuration/Entity.php
@@ -17,6 +17,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  * @author Ryan Weaver <ryan@knpuniversity.com>
  * @Annotation
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Entity extends ParamConverter
 {
     public function setExpr($expr)
@@ -25,5 +26,30 @@ class Entity extends ParamConverter
         $options['expr'] = $expr;
 
         $this->setOptions($options);
+    }
+
+    /**
+     * @param array|string $data
+     */
+    public function __construct(
+        $data = [],
+        string $expr = null,
+        string $class = null,
+        array $options = [],
+        bool $isOptional = false,
+        string $converter = null
+    ) {
+        $values = [];
+        if (\is_string($data)) {
+            $values['value'] = $data;
+        } else {
+            $values = $data;
+        }
+
+        $values['expr'] = $values['expr'] ?? $expr;
+
+        parent::__construct($values, $class, $options, $isOptional, $converter);
+
+        $this->setExpr($values['expr']);
     }
 }

--- a/src/Configuration/IsGranted.php
+++ b/src/Configuration/IsGranted.php
@@ -17,6 +17,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  * @author Ryan Weaver <ryan@knpuniversity.com>
  * @Annotation
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class IsGranted extends ConfigurationAnnotation
 {
     /**
@@ -49,6 +50,29 @@ class IsGranted extends ConfigurationAnnotation
      * @var int|null
      */
     private $statusCode;
+
+    /**
+     * @param mixed        $subject
+     * @param array|string $data
+     */
+    public function __construct(
+        $data = [],
+        $subject = null,
+        string $message = null,
+        ?int $statusCode = null
+    ) {
+        $values = [];
+        if (\is_string($data)) {
+            $values['attributes'] = $data;
+        } else {
+            $values = $data;
+        }
+
+        $values['subject'] = $values['subject'] ?? $subject;
+        $values['message'] = $values['message'] ?? $message;
+        $values['statusCode'] = $values['statusCode'] ?? $statusCode;
+        parent::__construct($values);
+    }
 
     public function setAttributes($attributes)
     {

--- a/src/Configuration/ParamConverter.php
+++ b/src/Configuration/ParamConverter.php
@@ -17,6 +17,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  * @author Fabien Potencier <fabien@symfony.com>
  * @Annotation
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class ParamConverter extends ConfigurationAnnotation
 {
     /**
@@ -53,6 +54,29 @@ class ParamConverter extends ConfigurationAnnotation
      * @var string
      */
     private $converter;
+
+    /**
+     * @param array|string $data
+     */
+    public function __construct(
+        $data = [],
+        string $class = null,
+        array $options = [],
+        bool $isOptional = false,
+        string $converter = null
+    ) {
+        $values = [];
+        if (\is_string($data)) {
+            $values['value'] = $data;
+        } else {
+            $values = $data;
+        }
+        $values['class'] = $values['class'] ?? $class;
+        $values['options'] = $values['options'] ?? $options;
+        $values['isOptional'] = $values['isOptional'] ?? $isOptional;
+        $values['converter'] = $values['converter'] ?? $converter;
+        parent::__construct($values);
+    }
 
     /**
      * Returns the parameter name.

--- a/src/Configuration/Security.php
+++ b/src/Configuration/Security.php
@@ -17,6 +17,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  * @author Fabien Potencier <fabien@symfony.com>
  * @Annotation
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Security extends ConfigurationAnnotation
 {
     /**
@@ -42,6 +43,27 @@ class Security extends ConfigurationAnnotation
      * @var string
      */
     protected $message = 'Access denied.';
+
+    /**
+     * @param array|string $data
+     */
+    public function __construct(
+        $data = [],
+        string $message = null,
+        ?int $statusCode = null
+    ) {
+        $values = [];
+        if (\is_string($data)) {
+            $values['expression'] = $data;
+        } else {
+            $values = $data;
+        }
+
+        $values['message'] = $values['message'] ?? $message;
+        $values['statusCode'] = $values['statusCode'] ?? $statusCode;
+
+        parent::__construct($values);
+    }
 
     public function getExpression()
     {

--- a/src/Configuration/Template.php
+++ b/src/Configuration/Template.php
@@ -17,6 +17,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
  * @author Fabien Potencier <fabien@symfony.com>
  * @Annotation
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 class Template extends ConfigurationAnnotation
 {
     /**
@@ -46,6 +47,29 @@ class Template extends ConfigurationAnnotation
      * @var array
      */
     private $owner = [];
+
+    /**
+     * @param array|string $data
+     */
+    public function __construct(
+        $data = [],
+        array $vars = [],
+        bool $isStreamable = false,
+        array $owner = []
+    ) {
+        $values = [];
+        if (\is_string($data)) {
+            $values['template'] = $data;
+        } else {
+            $values = $data;
+        }
+
+        $values['isStreamable'] = $values['isStreamable'] ?? $isStreamable;
+        $values['vars'] = $values['vars'] ?? $vars;
+        $values['owner'] = $values['owner'] ?? $owner;
+
+        parent::__construct($values);
+    }
 
     /**
      * Returns the array of templates variables.

--- a/src/EventListener/ControllerListener.php
+++ b/src/EventListener/ControllerListener.php
@@ -13,6 +13,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Persistence\Proxy;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
@@ -59,6 +60,24 @@ class ControllerListener implements EventSubscriberInterface
 
         $classConfigurations = $this->getConfigurations($this->reader->getClassAnnotations($object));
         $methodConfigurations = $this->getConfigurations($this->reader->getMethodAnnotations($method));
+
+        if (80000 <= \PHP_VERSION_ID) {
+            $classAttributes = array_map(
+                function (\ReflectionAttribute $attribute) {
+                    return $attribute->newInstance();
+                },
+                $object->getAttributes(ConfigurationAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF)
+            );
+            $classConfigurations = array_merge($classConfigurations, $this->getConfigurations($classAttributes));
+
+            $methodAttributes = array_map(
+                function (\ReflectionAttribute $attribute) {
+                    return $attribute->newInstance();
+                },
+                $method->getAttributes(ConfigurationAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF)
+            );
+            $methodConfigurations = array_merge($methodConfigurations, $this->getConfigurations($methodAttributes));
+        }
 
         $configurations = [];
         foreach (array_merge(array_keys($classConfigurations), array_keys($methodConfigurations)) as $key) {

--- a/tests/EventListener/ControllerListenerTest.php
+++ b/tests/EventListener/ControllerListenerTest.php
@@ -13,13 +13,34 @@ namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClass;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtClassAndMethod;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAttributeAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAttributeAtClassAndMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerCacheAttributeAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerEntityAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerEntityAttributeAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerIsGrantedAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerIsGrantedAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerIsGrantedAttributeAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerIsGrantedAttributeAtMethod;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerMultipleCacheAtClass;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerMultipleCacheAtMethod;
 use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerParamConverterAtClassAndMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerParamConverterAttributeAtClassAndMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerSecurityAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerSecurityAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerSecurityAttributeAtClass;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerSecurityAttributeAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerTemplateAtMethod;
+use Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture\FooControllerTemplateAttributeAtMethod;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -32,7 +53,7 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
         $this->request = $this->createRequest();
 
         // trigger the autoloading of the @Cache annotation
-        class_exists('Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache');
+        class_exists(Cache::class);
     }
 
     protected function tearDown(): void
@@ -52,9 +73,36 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(FooControllerCacheAtMethod::METHOD_SMAXAGE, $this->getReadedCache()->getSMaxAge());
     }
 
+    /**
+     * @requires PHP 8.0
+     */
+    public function testCacheAttributeAtMethod()
+    {
+        $controller = new FooControllerCacheAttributeAtMethod();
+
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAtMethod::METHOD_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
     public function testCacheAnnotationAtClass()
     {
         $controller = new FooControllerCacheAtClass();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAtClass::CLASS_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testCacheAttributeAtClass()
+    {
+        $controller = new FooControllerCacheAttributeAtClass();
         $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
         $this->listener->onKernelController($this->event);
 
@@ -76,6 +124,25 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotNull($this->getReadedCache());
         $this->assertEquals(FooControllerCacheAtClassAndMethod::CLASS_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testCacheAttributeAtClassAndMethod()
+    {
+        $controller = new FooControllerCacheAttributeAtClassAndMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAttributeAtClassAndMethod::METHOD_SMAXAGE, $this->getReadedCache()->getSMaxAge());
+
+        $this->event = $this->getFilterControllerEvent([$controller, 'bar2Action'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $this->assertNotNull($this->getReadedCache());
+        $this->assertEquals(FooControllerCacheAttributeAtClassAndMethod::CLASS_SMAXAGE, $this->getReadedCache()->getSMaxAge());
     }
 
     public function testMultipleAnnotationsOnClassThrowsExceptionUnlessConfigurationAllowsArray()
@@ -100,7 +167,7 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
 
     public function testMultipleParamConverterAnnotationsOnMethod()
     {
-        $paramConverter = new \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter([]);
+        $paramConverter = new ParamConverter([]);
         $controller = new FooControllerParamConverterAtClassAndMethod();
         $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
         $this->listener->onKernelController($this->event);
@@ -108,14 +175,216 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
         $annotations = $this->request->attributes->get('_converters');
         $this->assertNotNull($annotations);
         $this->assertArrayHasKey(0, $annotations);
-        $this->assertInstanceOf('Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter', $annotations[0]);
+        $this->assertInstanceOf(ParamConverter::class, $annotations[0]);
         $this->assertEquals('test', $annotations[0]->getName());
 
         $this->assertArrayHasKey(1, $annotations);
-        $this->assertInstanceOf('Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter', $annotations[1]);
+        $this->assertInstanceOf(ParamConverter::class, $annotations[1]);
         $this->assertEquals('test2', $annotations[1]->getName());
 
         $this->assertCount(2, $annotations);
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testMultipleParamConverterAttributesOnMethod()
+    {
+        $paramConverter = new ParamConverter([]);
+        $controller = new FooControllerParamConverterAttributeAtClassAndMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_converters');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(ParamConverter::class, $annotations[0]);
+        $this->assertEquals('test', $annotations[0]->getName());
+
+        $this->assertArrayHasKey(1, $annotations);
+        $this->assertInstanceOf(ParamConverter::class, $annotations[1]);
+        $this->assertEquals('test2', $annotations[1]->getName());
+
+        $this->assertCount(2, $annotations);
+    }
+
+    public function testEntityAnnotationOnMethod()
+    {
+        $controller = new FooControllerEntityAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_converters');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(Entity::class, $annotations[0]);
+        $this->assertEquals('foo', $annotations[0]->getName());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testEntityAttributeOnMethod()
+    {
+        $controller = new FooControllerEntityAttributeAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_converters');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(Entity::class, $annotations[0]);
+        $this->assertEquals('foo', $annotations[0]->getName());
+    }
+
+    public function testIsGrantedAnnotationOnClass()
+    {
+        $controller = new FooControllerIsGrantedAtClass();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_is_granted');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(IsGranted::class, $annotations[0]);
+        $this->assertEquals('ROLE_USER', $annotations[0]->getAttributes());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testIsGrantedAttributeOnClass()
+    {
+        $controller = new FooControllerIsGrantedAttributeAtClass();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_is_granted');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(IsGranted::class, $annotations[0]);
+        $this->assertEquals('ROLE_USER', $annotations[0]->getAttributes());
+    }
+
+    public function testIsGrantedAnnotationOnMethod()
+    {
+        $controller = new FooControllerIsGrantedAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_is_granted');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(1, $annotations);
+        $this->assertInstanceOf(IsGranted::class, $annotations[0]);
+        $this->assertEquals('ROLE_USER', $annotations[0]->getAttributes());
+        $this->assertInstanceOf(IsGranted::class, $annotations[1]);
+        $this->assertEquals('FOO_SHOW', $annotations[1]->getAttributes());
+        $this->assertEquals('foo', $annotations[1]->getSubject());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testIsGrantedAttributeOnMethod()
+    {
+        $controller = new FooControllerIsGrantedAttributeAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_is_granted');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(1, $annotations);
+        $this->assertInstanceOf(IsGranted::class, $annotations[0]);
+        $this->assertEquals('ROLE_USER', $annotations[0]->getAttributes());
+        $this->assertInstanceOf(IsGranted::class, $annotations[1]);
+        $this->assertEquals('FOO_SHOW', $annotations[1]->getAttributes());
+        $this->assertEquals('foo', $annotations[1]->getSubject());
+    }
+
+    public function testSecurityAnnotationOnClass()
+    {
+        $controller = new FooControllerSecurityAtClass();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_security');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(Security::class, $annotations[0]);
+        $this->assertEquals("is_granted('ROLE_USER')", $annotations[0]->getExpression());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testSecurityAttributeOnClass()
+    {
+        $controller = new FooControllerSecurityAttributeAtClass();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_security');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(Security::class, $annotations[0]);
+        $this->assertEquals("is_granted('ROLE_USER')", $annotations[0]->getExpression());
+    }
+
+    public function testSecurityAnnotationOnMethod()
+    {
+        $controller = new FooControllerSecurityAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_security');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(Security::class, $annotations[0]);
+        $this->assertEquals("is_granted('ROLE_USER') and is_granted('FOO_SHOW', foo)", $annotations[0]->getExpression());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testSecurityAttributeOnMethod()
+    {
+        $controller = new FooControllerSecurityAttributeAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotations = $this->request->attributes->get('_security');
+        $this->assertNotNull($annotations);
+        $this->assertArrayHasKey(0, $annotations);
+        $this->assertInstanceOf(Security::class, $annotations[0]);
+        $this->assertEquals("is_granted('ROLE_USER') and is_granted('FOO_SHOW', foo)", $annotations[0]->getExpression());
+    }
+
+    public function testTemplateAnnotationOnMethod()
+    {
+        $controller = new FooControllerTemplateAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+        $annotation = $this->request->attributes->get('_template');
+        $this->assertNotNull($annotation);
+        $this->assertInstanceOf(Template::class, $annotation);
+        $this->assertEquals('templates/bar.html.twig', $annotation->getTemplate());
+        $this->assertEquals(['foo'], $annotation->getVars());
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testTemplateAttributeOnMethod()
+    {
+        $controller = new FooControllerTemplateAttributeAtMethod();
+        $this->event = $this->getFilterControllerEvent([$controller, 'barAction'], $this->request);
+        $this->listener->onKernelController($this->event);
+
+        $annotation = $this->request->attributes->get('_template');
+        $this->assertNotNull($annotation);
+        $this->assertInstanceOf(Template::class, $annotation);
+        $this->assertEquals('templates/bar.html.twig', $annotation->getTemplate());
+        $this->assertEquals(['foo'], $annotation->getVars());
     }
 
     private function createRequest(Cache $cache = null)
@@ -127,7 +396,7 @@ class ControllerListenerTest extends \PHPUnit\Framework\TestCase
 
     private function getFilterControllerEvent($controller, Request $request)
     {
-        $mockKernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['', '']);
+        $mockKernel = $this->getMockForAbstractClass(\Symfony\Component\HttpKernel\Kernel::class, ['', '']);
 
         return new ControllerEvent($mockKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
     }

--- a/tests/EventListener/Fixture/FooControllerCacheAttributeAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerCacheAttributeAtClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+#[Cache(smaxage: 20)]
+class FooControllerCacheAttributeAtClass
+{
+    const CLASS_SMAXAGE = 20;
+
+    public function barAction()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerCacheAttributeAtClassAndMethod.php
+++ b/tests/EventListener/Fixture/FooControllerCacheAttributeAtClassAndMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+#[Cache(smaxage: 20)]
+class FooControllerCacheAttributeAtClassAndMethod
+{
+    const CLASS_SMAXAGE = 20;
+    const METHOD_SMAXAGE = 25;
+
+    #[Cache(smaxage: 25)]
+    public function barAction()
+    {
+    }
+
+    public function bar2Action()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerCacheAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerCacheAttributeAtMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+class FooControllerCacheAttributeAtMethod
+{
+    const METHOD_SMAXAGE = 15;
+
+    #[Cache(smaxage: 15)]
+    public function barAction()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerEntityAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerEntityAtMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+
+class FooControllerEntityAtMethod
+{
+    /**
+     * @Entity("foo", expr="repository.find(id)")
+     */
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerEntityAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerEntityAttributeAtMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+
+class FooControllerEntityAttributeAtMethod
+{
+    #[Entity('foo', expr: 'repository.find(id)')]
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerIsGrantedAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerIsGrantedAtClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+/**
+ * @IsGranted("ROLE_USER")
+ */
+class FooControllerIsGrantedAtClass
+{
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerIsGrantedAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerIsGrantedAtMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+class FooControllerIsGrantedAtMethod
+{
+    /**
+     * @IsGranted("ROLE_USER")
+     * @IsGranted("FOO_SHOW", subject="foo")
+     */
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerIsGrantedAttributeAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerIsGrantedAttributeAtClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+class FooControllerIsGrantedAttributeAtClass
+{
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerIsGrantedAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerIsGrantedAttributeAtMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+class FooControllerIsGrantedAttributeAtMethod
+{
+    #[IsGranted('ROLE_USER')]
+    #[IsGranted('FOO_SHOW', subject: 'foo')]
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerMultipleCacheAttributeAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerMultipleCacheAttributeAtClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+#[Cache()]
+#[Cache()]
+class FooControllerMultipleCacheAttributeAtClass
+{
+    public function barAction()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerMultipleCacheAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerMultipleCacheAttributeAtMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+class FooControllerMultipleCacheAttributeAtMethod
+{
+    #[Cache()]
+    #[Cache()]
+    public function barAction()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerParamConverterAttributeAtClassAndMethod.php
+++ b/tests/EventListener/Fixture/FooControllerParamConverterAttributeAtClassAndMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+#[ParamConverter('test')]
+class FooControllerParamConverterAttributeAtClassAndMethod
+{
+    #[ParamConverter('test2')]
+    public function barAction($test, $test2)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerSecurityAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerSecurityAtClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+/**
+ * @Security("is_granted('ROLE_USER')")
+ */
+class FooControllerSecurityAtClass
+{
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerSecurityAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerSecurityAtMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+class FooControllerSecurityAtMethod
+{
+    /**
+     * @Security("is_granted('ROLE_USER') and is_granted('FOO_SHOW', foo)")
+     */
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerSecurityAttributeAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerSecurityAttributeAtClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+#[Security("is_granted('ROLE_USER')")]
+class FooControllerSecurityAttributeAtClass
+{
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerSecurityAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerSecurityAttributeAtMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+class FooControllerSecurityAttributeAtMethod
+{
+    #[Security("is_granted('ROLE_USER') and is_granted('FOO_SHOW', foo)")]
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerTemplateAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerTemplateAtMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class FooControllerTemplateAtMethod
+{
+    /**
+     * @Template("templates/bar.html.twig", vars={"foo"})
+     */
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerTemplateAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerTemplateAttributeAtMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class FooControllerTemplateAttributeAtMethod
+{
+    #[Template('templates/bar.html.twig', vars: ['foo'])]
+    public function barAction($foo)
+    {
+    }
+}

--- a/tests/EventListener/HttpCacheListenerTest.php
+++ b/tests/EventListener/HttpCacheListenerTest.php
@@ -132,7 +132,7 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('5', $this->response->headers->getCacheControlDirective('max-stale'));
         $this->assertEquals('6', $this->response->headers->getCacheControlDirective('stale-while-revalidate'));
         $this->assertEquals('7', $this->response->headers->getCacheControlDirective('stale-if-error'));
-        $this->assertInstanceOf('DateTime', $this->response->getExpires());
+        $this->assertInstanceOf(\DateTime::class, $this->response->getExpires());
     }
 
     public function testCacheMaxAgeSupportsStrtotimeFormat()
@@ -194,7 +194,7 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
 
     public function testEtagNotModifiedResponse()
     {
-        $request = $this->createRequest(new Cache(['etag' => 'test.getId()']));
+        $request = $this->createRequest(new Cache(['Etag' => 'test.getId()']));
         $request->attributes->set('test', $entity = new TestEntity());
         $request->headers->add(['If-None-Match' => sprintf('"%s"', hash('sha256', $entity->getId()))]);
 
@@ -211,7 +211,7 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
 
     public function testEtagHeader()
     {
-        $request = $this->createRequest(new Cache(['ETag' => 'test.getId()']));
+        $request = $this->createRequest(new Cache(['Etag' => 'test.getId()']));
         $request->attributes->set('test', $entity = new TestEntity());
         $response = new Response();
 
@@ -276,7 +276,7 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
 
     private function getKernel()
     {
-        return $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
+        return $this->getMockBuilder(HttpKernelInterface::class)->getMock();
     }
 }
 

--- a/tests/EventListener/IsGrantedListenerTest.php
+++ b/tests/EventListener/IsGrantedListenerTest.php
@@ -17,6 +17,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentNameConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -153,7 +154,7 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
 
     public function testNotFoundHttpException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->expectException(HttpException::class);
         $this->expectExceptionMessage('Not found');
 
         $request = $this->createRequest(new IsGranted(['attributes' => 'ROLE_ADMIN', 'statusCode' => 404, 'message' => 'Not found']));


### PR DESCRIPTION
# Add PHP 8.0 attributes support

## Using PHP attributes if we start a new project on PHP 8.0

Instead of using classic doctrine annotations 
```php
    /**
     * @Cache(public=true, maxage="0", smaxage="1 month")
     * @IsGranted("ROLE_ADMIN")
     */
    public function foo() { }
```

We should use attributes PHP 8.0 
```php
    #[Cache(public: true, maxage: '0', smaxage: '1 month')]
    #[IsGranted('ROLE_ADMIN')]
    public function foo() { }
```

### Note for Etag attribute

In the documentation, we use Etag ( not etag or ETag used in the unit tests ). So, to simplify the code, I suggest to fix the unit test. What do you think about that ? 


Thank you for your reading :)