### PR TITLE
Restore undetermined state in Cache configuration

### DIFF
--- a/src/Configuration/Cache.php
+++ b/src/Configuration/Cache.php
@@ -114,11 +114,11 @@ class Cache extends ConfigurationAnnotation
         string $expires = null,
         $maxage = null,
         $smaxage = null,
-        bool $public = false,
-        bool $mustRevalidate = false,
-        array $vary = [],
-        ?string $lastModified = null,
-        ?string $etag = null,
+        bool $public = null,
+        bool $mustRevalidate = null,
+        array $vary = null,
+        string $lastModified = null,
+        string $etag = null,
         $maxstale = null,
         $staleWhileRevalidate = null,
         $staleIfError = null
@@ -135,6 +135,9 @@ class Cache extends ConfigurationAnnotation
         $values['staleWhileRevalidate'] = $values['staleWhileRevalidate'] ?? $staleWhileRevalidate;
         $values['staleIfError'] = $values['staleIfError'] ?? $staleIfError;
 
+        $values = array_filter($values, function ($v) {
+            return $v !== null;
+        });
         parent::__construct($values);
     }
 

--- a/tests/EventListener/HttpCacheListenerTest.php
+++ b/tests/EventListener/HttpCacheListenerTest.php
@@ -50,6 +50,18 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response, $this->event->getResponse());
     }
 
+    public function testResponseIsPublicIfSharedMaxAgeSetAndPublicNotOverridden()
+    {
+        $request = $this->createRequest(new Cache([
+            'smaxage' => 1,
+        ]));
+
+        $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
+
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('public'));
+        $this->assertFalse($this->response->headers->hasCacheControlDirective('private'));
+    }
+
     public function testResponseIsPublicIfConfigurationIsPublicTrue()
     {
         $request = $this->createRequest(new Cache([
@@ -65,8 +77,8 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
     public function testResponseIsPrivateIfConfigurationIsPublicFalse()
     {
         $request = $this->createRequest(new Cache([
-                    'public' => false,
-                ]));
+            'public' => false,
+        ]));
 
         $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
 


### PR DESCRIPTION
This PR fix a BC break introduced by #707.

Given the following code:
```
    /**
     * @Cache(smaxage="+1min")
     */
    public function fooAction(){}
```

The headers generated by `HttpCacheListener` changed as following:
```diff
- public, s-maxage=60
+ private, s-maxage=60
```

Why? Because previously the Cache's properties were null until the user provide a value. In such state, `isPublic` returns false (although `isPrivate`). And sometimes, null is expected (like the `vary` array => https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/b3596907c3d35bee5a9a1096baaeb7d465a04f30/src/EventListener/HttpCacheListener.php#L135)

The #707 PR introduce 2 changes:
- a value for each property is now forced by the constructor's default value.
- the constructor calls the setter for each property (even if the user did not provide a value for it), some setter (ie. `setPublic`) does not expect a null value and convert null into something.

It looks like, only the Cache configuration is affected. Other Configuration has already a default value defined for each property.

This PR restore the default `null` value for all properties and prevent the constructor to call the setter when the value is null.