### PR TITLE
bug #699 Accept null arguments as subjects for IsGranted annotation

### DIFF
--- a/src/EventListener/IsGrantedListener.php
+++ b/src/EventListener/IsGrantedListener.php
@@ -58,14 +58,14 @@ class IsGrantedListener implements EventSubscriberInterface
             if ($subjectRef) {
                 if (\is_array($subjectRef)) {
                     foreach ($subjectRef as $ref) {
-                        if (!isset($arguments[$ref])) {
+                        if (!\array_key_exists($ref, $arguments)) {
                             throw $this->createMissingSubjectException($ref);
                         }
 
                         $subject[$ref] = $arguments[$ref];
                     }
                 } else {
-                    if (!isset($arguments[$subjectRef])) {
+                    if (!\array_key_exists($subjectRef, $arguments)) {
                         throw $this->createMissingSubjectException($subjectRef);
                     }
 

--- a/tests/EventListener/IsGrantedListenerTest.php
+++ b/tests/EventListener/IsGrantedListenerTest.php
@@ -98,6 +98,39 @@ class IsGrantedListenerTest extends \PHPUnit\Framework\TestCase
         $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
     }
 
+    public function testIsGrantedNullSubjectFromArguments()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        // createRequest() puts 2 IsGranted annotations into the config
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            ->with('ROLE_ADMIN', null)
+            ->willReturn(true);
+
+        $listener = new IsGrantedListener($this->createArgumentNameConverter(['arg1Name' => 'arg1Value', 'arg2Name' => null]), $authChecker);
+        $isGranted = new IsGranted(['attributes' => 'ROLE_ADMIN', 'subject' => 'arg2Name']);
+        $request = $this->createRequest($isGranted);
+        $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+    }
+
+    public function testIsGrantedArrayWithNullValueSubjectFromArguments()
+    {
+        $authChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
+        // createRequest() puts 2 IsGranted annotations into the config
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            ->with('ROLE_ADMIN', [
+                'arg1Name' => 'arg1Value',
+                'arg2Name' => null,
+            ])
+            ->willReturn(true);
+
+        $listener = new IsGrantedListener($this->createArgumentNameConverter(['arg1Name' => 'arg1Value', 'arg2Name' => null]), $authChecker);
+        $isGranted = new IsGranted(['attributes' => 'ROLE_ADMIN', 'subject' => ['arg1Name', 'arg2Name']]);
+        $request = $this->createRequest($isGranted);
+        $listener->onKernelControllerArguments($this->createFilterControllerEvent($request));
+    }
+
     public function testExceptionWhenMissingSubjectAttribute()
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
This PR solves #699 by managing nullable subjects or array subjects with null values on existing keys.

This may also replace a previous PR #703 
