### PR TITLE
Don't skip interfaces for auto-conversion

### DIFF
--- a/src/EventListener/ParamConverterListener.php
+++ b/src/EventListener/ParamConverterListener.php
@@ -106,19 +106,12 @@ class ParamConverterListener implements EventSubscriberInterface
 
     private function getParamClassByType(?\ReflectionType $type): ?string
     {
-        if (\PHP_VERSION_ID < 80000) {
-            return (null === $type || $type->isBuiltin() || !$type instanceof \ReflectionNamedType) ?
-                null : $type->getName();
+        if (null === $type) {
+            return null;
         }
 
         foreach ($type instanceof \ReflectionUnionType ? $type->getTypes() : [$type] as $type) {
-            if (null === $type || $type->isBuiltin() || !$type instanceof \ReflectionNamedType) {
-                continue;
-            }
-
-            $class = new \ReflectionClass($type->getName());
-
-            if (!$class->isInterface() && !$class->isAbstract()) {
+            if (!$type->isBuiltin()) {
                 return $type->getName();
             }
         }

--- a/tests/EventListener/Fixture/InvokableControllerWithUnion.php
+++ b/tests/EventListener/Fixture/InvokableControllerWithUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+final class InvokableControllerWithUnion
+{
+    public function __invoke(int | \DateTime | string $date)
+    {
+    }
+}


### PR DESCRIPTION
This PR fixes a problem introduced by #727. Before said patch, configuring a param converter for an interface was possible. I've added a test to make sure that this use-case does not break again. In addition to that, I've simplified the code a bit.