### PR TITLE
Extend PHP 8.0 attribute support to `ConfigurationInterface`

### DIFF
--- a/src/EventListener/ControllerListener.php
+++ b/src/EventListener/ControllerListener.php
@@ -13,7 +13,6 @@ namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Persistence\Proxy;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
@@ -66,7 +65,7 @@ class ControllerListener implements EventSubscriberInterface
                 function (\ReflectionAttribute $attribute) {
                     return $attribute->newInstance();
                 },
-                $object->getAttributes(ConfigurationAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF)
+                $object->getAttributes(ConfigurationInterface::class, \ReflectionAttribute::IS_INSTANCEOF)
             );
             $classConfigurations = array_merge($classConfigurations, $this->getConfigurations($classAttributes));
 
@@ -74,7 +73,7 @@ class ControllerListener implements EventSubscriberInterface
                 function (\ReflectionAttribute $attribute) {
                     return $attribute->newInstance();
                 },
-                $method->getAttributes(ConfigurationAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF)
+                $method->getAttributes(ConfigurationInterface::class, \ReflectionAttribute::IS_INSTANCEOF)
             );
             $methodConfigurations = array_merge($methodConfigurations, $this->getConfigurations($methodAttributes));
         }

--- a/tests/EventListener/Fixture/CustomAttribute.php
+++ b/tests/EventListener/Fixture/CustomAttribute.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class CustomAttribute implements ConfigurationInterface
+{
+    private $custom;
+
+    public function __construct(
+        array $values = [],
+        string $custom = null
+    ) {
+        $this->custom = $values['custom'] ?? $custom;
+    }
+
+    public function getCustom()
+    {
+        return $this->custom;
+    }
+
+    public function getAliasName()
+    {
+        return 'custom';
+    }
+
+    public function allowArray()
+    {
+        return false;
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerCustomAttributeAtClass.php
+++ b/tests/EventListener/Fixture/FooControllerCustomAttributeAtClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+#[CustomAttribute(custom: 'class')]
+class FooControllerCustomAttributeAtClass
+{
+    const CLASS_CUSTOM = 'class';
+
+    public function barAction()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerCustomAttributeAtClassAndMethod.php
+++ b/tests/EventListener/Fixture/FooControllerCustomAttributeAtClassAndMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+#[CustomAttribute(custom: 'class')]
+class FooControllerCustomAttributeAtClassAndMethod
+{
+    const CLASS_CUSTOM = 'class';
+    const METHOD_CUSTOM = 'func';
+
+    #[CustomAttribute(custom: 'func')]
+    public function barAction()
+    {
+    }
+
+    public function bar2Action()
+    {
+    }
+}

--- a/tests/EventListener/Fixture/FooControllerCustomAttributeAtMethod.php
+++ b/tests/EventListener/Fixture/FooControllerCustomAttributeAtMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\EventListener\Fixture;
+
+class FooControllerCustomAttributeAtMethod
+{
+    const METHOD_CUSTOM = 'func';
+
+    #[CustomAttribute(custom: 'func')]
+    public function barAction()
+    {
+    }
+}


### PR DESCRIPTION
This PR replaces `Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation` with `Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface` when processing PHP 8.0 attributes. This allows custom annotations/attributes to directly implement `ConfigurationInterface` rather than extend `ConfigurationAnnotation`.

Closes #730.