### PR TITLE
Add a DateInterval ParamConverter

### DIFF
--- a/src/Request/ParamConverter/DateIntervalParamConverter.php
+++ b/src/Request/ParamConverter/DateIntervalParamConverter.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Convert DateInterval instances from request attribute variable.
+ *
+ * @author Laurent Georget <laurent.georget@meteo-concept.fr>
+ */
+class DateIntervalParamConverter implements ParamConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws NotFoundHttpException When invalid date given
+     */
+    public function apply(Request $request, ParamConverter $configuration)
+    {
+        $param = $configuration->getName();
+
+        if (!$request->attributes->has($param)) {
+            return false;
+        }
+
+        $options = $configuration->getOptions();
+        $value = $request->attributes->get($param);
+
+        if (!$value && $configuration->isOptional()) {
+            $request->attributes->set($param, null);
+
+            return true;
+        }
+
+        $class = $configuration->getClass();
+
+        $interval = false;
+        try {
+            // Attempt first to parse the param as a ISO8601 date interval.
+            $interval = new $class($value);
+        } catch (\Exception $e) {
+            // Didn't quite work, let's try to see if it's a valid date string.
+            // The function first passes the value to strtotime() because
+            // createFromDateString() can sometimes throw when trying to parse
+            // some element of the value as a timezone only to then fail to
+            // find it in the tzdata database.
+            if (false !== strtotime($value)) {
+                $interval = $class::createFromDateString($value);
+            }
+            if (false === $interval) {
+                throw new NotFoundHttpException(sprintf('Invalid date interval given for parameter "%s".', $param));
+            }
+        }
+
+        $request->attributes->set($param, $interval);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(ParamConverter $configuration)
+    {
+        if (null === $configuration->getClass()) {
+            return false;
+        }
+
+        return \DateInterval::class === $configuration->getClass() ||
+               is_subclass_of($configuration->getClass(), \DateInterval::class);
+    }
+}

--- a/tests/Fixtures/FooDateInterval.php
+++ b/tests/Fixtures/FooDateInterval.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Fixtures;
+
+class FooDateInterval extends \DateInterval
+{
+}

--- a/tests/Request/ParamConverter/DateIntervalParamConverterTest.php
+++ b/tests/Request/ParamConverter/DateIntervalParamConverterTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Tests\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DateIntervalParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\Fixtures;
+
+class DateIntervalParamConverterTest extends \PHPUnit\Framework\TestCase
+{
+    private $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DateIntervalParamConverter();
+    }
+
+    public function testSupports()
+    {
+        $config = $this->createConfiguration(\DateInterval::class);
+        $this->assertTrue($this->converter->supports($config));
+
+        $config = $this->createConfiguration(Fixtures\FooDateInterval::class);
+        $this->assertTrue($this->converter->supports($config));
+
+        $config = $this->createConfiguration(__CLASS__);
+        $this->assertFalse($this->converter->supports($config));
+
+        $config = $this->createConfiguration();
+        $this->assertFalse($this->converter->supports($config));
+    }
+
+    public function testApplyIso8601()
+    {
+        $request = new Request([], [], ['start' => 'P1DT3H30M']);
+        $config = $this->createConfiguration(\DateInterval::class, 'start');
+
+        $this->converter->apply($request, $config);
+
+        $this->assertInstanceOf(\DateInterval::class, $request->attributes->get('start'));
+        $this->assertEquals('1 day, 3 hours, 30 minutes', $request->attributes->get('start')->format('%d day, %h hours, %i minutes'));
+    }
+
+    public function testApplyDateString()
+    {
+        $request = new Request([], [], ['start' => '2 weeks']);
+        $config = $this->createConfiguration(\DateInterval::class, 'start');
+
+        $this->converter->apply($request, $config);
+
+        $this->assertInstanceOf(\DateInterval::class, $request->attributes->get('start'));
+        $this->assertEquals('14', $request->attributes->get('start')->format('%d'));
+    }
+
+    public function testApplyInvalidDateInterval404Exception()
+    {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectExceptionMessage('Invalid date interval given for parameter "start".');
+
+        $request = new Request([], [], ['start' => 'invalid date interval']);
+        $config = $this->createConfiguration(\DateInterval::class, 'start');
+
+        $this->converter->apply($request, $config);
+    }
+
+    public function testApplyOptionalWithEmptyAttribute()
+    {
+        $request = new Request([], [], ['start' => '']);
+        $config = $this->createConfiguration(\DateInterval::class, 'start');
+        $config->expects($this->once())
+            ->method('isOptional')
+            ->willReturn(true);
+
+        $this->assertTrue($this->converter->apply($request, $config));
+        $this->assertNull($request->attributes->get('start'));
+    }
+
+    public function testApplyCustomClass()
+    {
+        $request = new Request([], [], ['start' => 'P1DT3H30M']);
+        $config = $this->createConfiguration(Fixtures\FooDateInterval::class, 'start');
+
+        $this->converter->apply($request, $config);
+
+        $this->assertInstanceOf(Fixtures\FooDateInterval::class, $request->attributes->get('start'));
+        $this->assertEquals('1 day, 3 hours, 30 minutes', $request->attributes->get('start')->format('%d day, %h hours, %i minutes'));
+    }
+
+    public function createConfiguration($class = null, $name = null)
+    {
+        $config = $this
+            ->getMockBuilder(Configuration\ParamConverter::class)
+            ->setMethods(['getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray', 'isOptional'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        if (null !== $name) {
+            $config->expects($this->any())
+                   ->method('getName')
+                   ->willReturn($name);
+        }
+        if (null !== $class) {
+            $config->expects($this->any())
+                   ->method('getClass')
+                   ->willReturn($class);
+        }
+
+        return $config;
+    }
+}


### PR DESCRIPTION
Hi!

I don't know if you're interested in this kind of contribution but I needed a ParamConverter for DateInterval objects in a project lately and I thought it could be a useful addition to this bundle along with the already present DateInterval converter.

This converter converts string such as "P1DT3H30M" or "2 weeks" passed as parameter URLs into DateInterval objects.

I've also added some tests of course, mostly by copying what had been done for DateTimeParamConverter. Let me know if more are needed.

Cheers,

Laurent