### PR TITLE
Update index.rst

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -150,6 +150,7 @@ the other examples both plain old annotations and PHP 8.0 are shown):
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
         #[Route('/blog')]
+        #[Cache(expired: 'tomorrow')]
         class AnnotController
         {
             #[Route('/')]


### PR DESCRIPTION
`#[Cache(expired: 'tomorrow')]` attribute is omitted in code block. I think, it should be added for compatibility.