### PR TITLE
Fix Symfony 6 BC break with required attributes in routing.xml

### DIFF
--- a/src/Resources/config/routing.xml
+++ b/src/Resources/config/routing.xml
@@ -8,21 +8,21 @@
         <service id="sensio_framework_extra.routing.loader.annot_class" class="Sensio\Bundle\FrameworkExtraBundle\Routing\AnnotatedRouteControllerLoader">
             <tag name="routing.loader" />
             <argument type="service" id="annotation_reader" />
-            <deprecated>The "%service_id%" service is deprecated since version 5.2</deprecated>
+            <deprecated package="sensio/framework-extra-bundle" version="5.2">The "%service_id%" service is deprecated since version 5.2</deprecated>
         </service>
 
         <service id="sensio_framework_extra.routing.loader.annot_dir" class="Symfony\Component\Routing\Loader\AnnotationDirectoryLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
             <argument type="service" id="sensio_framework_extra.routing.loader.annot_class" />
-            <deprecated>The "%service_id%" service is deprecated since version 5.2</deprecated>
+            <deprecated package="sensio/framework-extra-bundle" version="5.2">The "%service_id%" service is deprecated since version 5.2</deprecated>
         </service>
 
         <service id="sensio_framework_extra.routing.loader.annot_file" class="Symfony\Component\Routing\Loader\AnnotationFileLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
             <argument type="service" id="sensio_framework_extra.routing.loader.annot_class" />
-            <deprecated>The "%service_id%" service is deprecated since version 5.2</deprecated>
+            <deprecated package="sensio/framework-extra-bundle" version="5.2">The "%service_id%" service is deprecated since version 5.2</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Closes https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/758

Closes https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/721