### PR TITLE
Update Kernel::registerBundles() with Symfony 6 return type

### DIFF
--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class TestKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),


### PR DESCRIPTION
Fixes https://github.com/sensiolabs/SensioFrameworkExtraBundle/runs/4555649344?check_suite_focus=true