### PR TITLE
Fix Symfony 6 BC break with required attributes in routing.xml

### DIFF
--- a/src/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/src/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage as SecurityExpressionLanguage;
 
 /**
@@ -39,7 +40,11 @@ class SensioFrameworkExtraExtension extends Extension
         if ($config['router']['annotations']) {
             @trigger_error(sprintf('Enabling the "sensio_framework_extra.router.annotations" configuration is deprecated since version 5.2. Set it to false and use the "%s" annotation from Symfony itself.', \Symfony\Component\Routing\Annotation\Route::class), \E_USER_DEPRECATED);
 
-            $annotationsToLoad[] = 'routing.xml';
+            if (Kernel::MAJOR_VERSION < 5) {
+                $annotationsToLoad[] = 'routing-4.4.xml';
+            } else {
+                $annotationsToLoad[] = 'routing.xml';
+            }
         }
 
         if ($config['request']['converters']) {

--- a/src/Resources/config/routing-4.4.xml
+++ b/src/Resources/config/routing-4.4.xml
@@ -8,21 +8,21 @@
         <service id="sensio_framework_extra.routing.loader.annot_class" class="Sensio\Bundle\FrameworkExtraBundle\Routing\AnnotatedRouteControllerLoader">
             <tag name="routing.loader" />
             <argument type="service" id="annotation_reader" />
-            <deprecated package="sensio/framework-extra-bundle" version="5.2">The "%service_id%" service is deprecated since version 5.2</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since version 5.2</deprecated>
         </service>
 
         <service id="sensio_framework_extra.routing.loader.annot_dir" class="Symfony\Component\Routing\Loader\AnnotationDirectoryLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
             <argument type="service" id="sensio_framework_extra.routing.loader.annot_class" />
-            <deprecated package="sensio/framework-extra-bundle" version="5.2">The "%service_id%" service is deprecated since version 5.2</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since version 5.2</deprecated>
         </service>
 
         <service id="sensio_framework_extra.routing.loader.annot_file" class="Symfony\Component\Routing\Loader\AnnotationFileLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
             <argument type="service" id="sensio_framework_extra.routing.loader.annot_class" />
-            <deprecated package="sensio/framework-extra-bundle" version="5.2">The "%service_id%" service is deprecated since version 5.2</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since version 5.2</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Followup for #759