### PR TITLE
Make the SecurityListener compatible with new Authenticator for #736

### DIFF
--- a/src/DependencyInjection/Compiler/EnableAuthenticatorManagerPass.php
+++ b/src/DependencyInjection/Compiler/EnableAuthenticatorManagerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Optimizes the container by removing unneeded listeners.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EnableAuthenticatorManagerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {          
+        if(!$container->has('sensio_framework_extra.security.listener')){
+            return;
+        }
+        
+        if(!$container->hasExtension('security')){
+            return;
+        }
+        
+        $securityConfig = $container->getExtensionConfig('security')[0];
+                
+        if (array_key_exists('enable_authenticator_manager', $securityConfig)) {
+            if($securityConfig['enable_authenticator_manager']){
+                $container->getDefinition('sensio_framework_extra.security.listener')->setArgument('$useNewAuthSystem', true);
+            }
+        }
+    }
+}

--- a/src/SensioFrameworkExtraBundle.php
+++ b/src/SensioFrameworkExtraBundle.php
@@ -13,6 +13,7 @@ namespace Sensio\Bundle\FrameworkExtraBundle;
 
 use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
 use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\AddParamConverterPass;
+use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\EnableAuthenticatorManagerPass;
 use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\OptimizerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -29,5 +30,6 @@ class SensioFrameworkExtraBundle extends Bundle
         $container->addCompilerPass(new AddParamConverterPass());
         $container->addCompilerPass(new OptimizerPass());
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
+        $container->addCompilerPass(new EnableAuthenticatorManagerPass());
     }
 }


### PR DESCRIPTION
Fixes #736 

Symfony Authentication system has changed between version 5.2 and 5.4.
The security bundle uses a config option 'enable_authenticator_manager' set to true if the new system is used.