### PR TITLE
[Fix] PHP 81 deprecated implicit conversion from float to int

### DIFF
--- a/src/EventListener/HttpCacheListener.php
+++ b/src/EventListener/HttpCacheListener.php
@@ -190,7 +190,7 @@ class HttpCacheListener implements EventSubscriberInterface
         if (!is_numeric($time)) {
             $now = microtime(true);
 
-            $time = ceil(strtotime($time, $now) - $now);
+            $time = ceil(strtotime($time, (int) $now) - $now);
         }
 
         return $time;


### PR DESCRIPTION
Hi everybody ! 

This PR fix a deprecated with PHP 8.1

`Deprecated: Implicit conversion from float 1643798519.685619 to int loses precision`

Thanks for your review !