### PR TITLE
[ParamConverter][Docs] DateTimeParamConverter allows unix timestamp

### DIFF
--- a/src/Resources/doc/annotations/converters.rst
+++ b/src/Resources/doc/annotations/converters.rst
@@ -360,7 +360,7 @@ instance:
         }
 
 By default, any date format that can be parsed by the ``DateTime`` constructor
-or an unix timestamp is accepted. You can be stricter with input given through the options:
+or a unix timestamp is accepted. You can be stricter with input given through the options:
 
 .. configuration-block::
 

--- a/src/Resources/doc/annotations/converters.rst
+++ b/src/Resources/doc/annotations/converters.rst
@@ -360,7 +360,7 @@ instance:
         }
 
 By default, any date format that can be parsed by the ``DateTime`` constructor
-or an unixtimestamp is accepted. You can be stricter with input given through the options:
+or an unix timestamp is accepted. You can be stricter with input given through the options:
 
 .. configuration-block::
 

--- a/src/Resources/doc/annotations/converters.rst
+++ b/src/Resources/doc/annotations/converters.rst
@@ -359,8 +359,8 @@ instance:
         {
         }
 
-By default any date format that can be parsed by the ``DateTime`` constructor
-is accepted. You can be stricter with input given through the options:
+By default, any date format that can be parsed by the ``DateTime`` constructor
+or an unixtimestamp is accepted. You can be stricter with input given through the options:
 
 .. configuration-block::
 


### PR DESCRIPTION
I made a PR quite a while back that has been merged which also allows the use of unix timestamp https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/654/commits/89d6f6218406d8c62349f0a28706563755332af0

Never made a PR for the docs I noticed just now so here it is.