### PR TITLE
Update ParamConverter.php

### DIFF
--- a/src/Configuration/ParamConverter.php
+++ b/src/Configuration/ParamConverter.php
@@ -111,7 +111,7 @@ class ParamConverter extends ConfigurationAnnotation
     /**
      * Returns the parameter class name.
      *
-     * @return string $name
+     * @return string
      */
     public function getClass()
     {


### PR DESCRIPTION
Removed obsolete `$name` from `@return` annotation.