### PR TITLE
PHP 8.2 Compatibility DateTime::getLastErrors

### DIFF
--- a/src/Request/ParamConverter/DateTimeParamConverter.php
+++ b/src/Request/ParamConverter/DateTimeParamConverter.php
@@ -49,7 +49,9 @@ class DateTimeParamConverter implements ParamConverterInterface
         if (isset($options['format'])) {
             $date = $class::createFromFormat($options['format'], $value);
 
-            if (0 < \DateTime::getLastErrors()['warning_count']) {
+            $errors = \DateTime::getLastErrors() ?: ['warning_count' => 0];
+
+            if (0 < $errors['warning_count']) {
                 $date = false;
             }
 


### PR DESCRIPTION
DateTime::getLastErrors() is documented as returning `array|false` https://www.php.net/manual/en/datetime.getlasterrors.php

As discussed here https://github.com/symfony/symfony/pull/47428#issuecomment-1231483492 

@derickr quoted as saying 
"This is a bug fix as the new 8.2 behaviour is how it has been documented for over a decade."