### PR TITLE
Check _cache type for compatibility with Symfony 6.2

### DIFF
--- a/src/EventListener/HttpCacheListener.php
+++ b/src/EventListener/HttpCacheListener.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\FrameworkExtraBundle\EventListener;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,7 +43,8 @@ class HttpCacheListener implements EventSubscriberInterface
     public function onKernelController(KernelEvent $event)
     {
         $request = $event->getRequest();
-        if (!$configuration = $request->attributes->get('_cache')) {
+        $configuration = $request->attributes->get('_cache');
+        if (!$configuration instanceof Cache) {
             return;
         }
 
@@ -81,8 +83,9 @@ class HttpCacheListener implements EventSubscriberInterface
     public function onKernelResponse(KernelEvent $event)
     {
         $request = $event->getRequest();
+        $configuration = $request->attributes->get('_cache');
 
-        if (!$configuration = $request->attributes->get('_cache')) {
+        if (!$configuration instanceof Cache) {
             return;
         }
 

--- a/tests/EventListener/HttpCacheListenerTest.php
+++ b/tests/EventListener/HttpCacheListenerTest.php
@@ -50,6 +50,16 @@ class HttpCacheListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response, $this->event->getResponse());
     }
 
+    public function testIgnoreUnknownCacheAttribute()
+    {
+        $response = $this->event->getResponse();
+
+        $this->request->attributes->set('_cache', new \stdClass());
+
+        $this->assertNull($this->listener->onKernelResponse($this->event));
+        $this->assertSame($response, $this->event->getResponse());
+    }
+
     public function testResponseIsPublicIfSharedMaxAgeSetAndPublicNotOverridden()
     {
         $request = $this->createRequest(new Cache([


### PR DESCRIPTION
The new `#[Cache()]` attribute that is added to Symfony 6.2 (https://github.com/symfony/symfony/pull/46880) is stored in the same request attribute `_cache`.

Before this change, if the bundle is enabled and Symfony's Cache attribute is used, we get an error.

```
Call to a member function getSMaxAge() on array
```

This bugfix will ease migration when simultaneously usage of FrameworkExtraBundle and Symfony attributes is necessary.