### PR TITLE
Add some native return types to prevent deprecation hints

### DIFF
--- a/src/DependencyInjection/SensioFrameworkExtraExtension.php
+++ b/src/DependencyInjection/SensioFrameworkExtraExtension.php
@@ -122,10 +122,7 @@ class SensioFrameworkExtraExtension extends Extension
         return __DIR__.'/../Resources/config/schema';
     }
 
-    /**
-     * @return string
-     */
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://symfony.com/schema/dic/symfony_extra';
     }

--- a/src/EventListener/ControllerListener.php
+++ b/src/EventListener/ControllerListener.php
@@ -121,10 +121,7 @@ class ControllerListener implements EventSubscriberInterface
         return $configurations;
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/src/EventListener/HttpCacheListener.php
+++ b/src/EventListener/HttpCacheListener.php
@@ -160,10 +160,7 @@ class HttpCacheListener implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/src/EventListener/IsGrantedListener.php
+++ b/src/EventListener/IsGrantedListener.php
@@ -114,10 +114,7 @@ class IsGrantedListener implements EventSubscriberInterface
         return $argsString;
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [KernelEvents::CONTROLLER_ARGUMENTS => 'onKernelControllerArguments'];
     }

--- a/src/EventListener/ParamConverterListener.php
+++ b/src/EventListener/ParamConverterListener.php
@@ -119,10 +119,7 @@ class ParamConverterListener implements EventSubscriberInterface
         return null;
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/src/EventListener/SecurityListener.php
+++ b/src/EventListener/SecurityListener.php
@@ -142,10 +142,7 @@ class SecurityListener implements EventSubscriberInterface
         return $roles;
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [KernelEvents::CONTROLLER_ARGUMENTS => 'onKernelControllerArguments'];
     }

--- a/src/EventListener/TemplateListener.php
+++ b/src/EventListener/TemplateListener.php
@@ -119,10 +119,7 @@ class TemplateListener implements EventSubscriberInterface, ServiceSubscriberInt
         $template->setOwner([]);
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => ['onKernelController', -128],


### PR DESCRIPTION
Fixes several deprecation messages:
```
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Sensio\Bundle\FrameworkExtraBundle\EventListener\XXXListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::getNamespace()" might add "string" as a native return type declaration in the future. Do the same in implementation "Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\SensioFrameworkExtraExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
```

It will not affect negative for all Symfony and  PHP versions currently supported