### PR TITLE
Allow Doctrine annotations v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "doctrine/annotations": "^1.0",
+        "doctrine/annotations": "^1.0|^2.0",
         "symfony/config": "^4.4|^5.0|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/framework-bundle": "^4.4|^5.0|^6.0",

--- a/tests/Routing/AnnotatedRouteControllerLoaderTest.php
+++ b/tests/Routing/AnnotatedRouteControllerLoaderTest.php
@@ -110,7 +110,9 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit\Framework\TestCase
     public function testLoad()
     {
         $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
-        AnnotationRegistry::registerLoader('class_exists');
+        if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+            AnnotationRegistry::registerLoader('class_exists');
+        }
 
         $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\FoobarController');
 
@@ -135,7 +137,9 @@ class AnnotatedRouteControllerLoaderTest extends \PHPUnit\Framework\TestCase
     public function testInvokableControllerLoad()
     {
         $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
-        AnnotationRegistry::registerLoader('class_exists');
+        if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+            AnnotationRegistry::registerLoader('class_exists');
+        }
 
         $rc = $loader->load('Sensio\Bundle\FrameworkExtraBundle\Tests\Routing\Fixtures\InvokableController');
 


### PR DESCRIPTION
I know there's a deprecation notice in the readme.md about this project, but we are using the latest Symfony 5.4 LTS and we can't migrate off this bundle until we update to at least 6.2 since the entity value resolver which is a replacement for the Doctrine param converter that this bundle provides has only been added in >= 6.2

And as this bundle requires Doctrine annotations v1 we can't update PHP-CS fixer to the latest version as they've dropped support for Doctrine annotations v1 which then also blocks us from upgrading PHPUnit to v10 as PHP-CS fixer added support for it in their latest version (as both PHP-CS fixer and PHPUnit depend on `sebastian/diff`).

So hopefully this is gonna be merged as there are no changes needed in the bundle for it to be able to support Doctrine annotations v2 and it'd unblock this dependency hell that I've described above.